### PR TITLE
container: change XxxContainers() return behaviour

### DIFF
--- a/lxc.go
+++ b/lxc.go
@@ -98,17 +98,17 @@ func ContainerNames(lxcpath ...string) []string {
 	return convertNArgs(cnames, size)
 }
 
-// Containers returns the defined and active containers on the system.
+// Containers returns the defined and active containers on the system. Only
+// containers that could retrieved successfully are returned.
 func Containers(lxcpath ...string) []Container {
 	var containers []Container
 
 	for _, v := range ContainerNames(lxcpath...) {
-		container, err := NewContainer(v, lxcpath...)
-		if err != nil {
-			return nil
+		if container, err := NewContainer(v, lxcpath...); err == nil {
+			containers = append(containers, *container)
 		}
-		containers = append(containers, *container)
 	}
+
 	return containers
 }
 
@@ -133,17 +133,17 @@ func DefinedContainerNames(lxcpath ...string) []string {
 	return convertNArgs(cnames, size)
 }
 
-// DefinedContainers returns the defined containers on the system.
+// DefinedContainers returns the defined containers on the system.  Only
+// containers that could retrieved successfully are returned.
 func DefinedContainers(lxcpath ...string) []Container {
 	var containers []Container
 
 	for _, v := range DefinedContainerNames(lxcpath...) {
-		container, err := NewContainer(v, lxcpath...)
-		if err != nil {
-			return nil
+		if container, err := NewContainer(v, lxcpath...); err == nil {
+			containers = append(containers, *container)
 		}
-		containers = append(containers, *container)
 	}
+
 	return containers
 }
 
@@ -168,16 +168,16 @@ func ActiveContainerNames(lxcpath ...string) []string {
 	return convertNArgs(cnames, size)
 }
 
-// ActiveContainers returns the active containers on the system.
+// ActiveContainers returns the active containers on the system. Only
+// containers that could retrieved successfully are returned.
 func ActiveContainers(lxcpath ...string) []Container {
 	var containers []Container
 
 	for _, v := range ActiveContainerNames(lxcpath...) {
-		container, err := NewContainer(v, lxcpath...)
-		if err != nil {
-			return nil
+		if container, err := NewContainer(v, lxcpath...); err == nil {
+			containers = append(containers, *container)
 		}
-		containers = append(containers, *container)
 	}
+
 	return containers
 }


### PR DESCRIPTION
I didn't know whether to open or not. You might have your reasons to do things differently but I'll give a shot.

Problems:
1. Previously when a NewContainer() creating fails the whole
   process would return a nil. That would be not acceptable for large
   number of containers. I.e: if we had 100 containers, one buggy
   container retrieval would cause to not get the rest 99 containers.
2. A list of values is prepared by dereferencing a container type and
   appending it to a []Container slice. However this again is not much
   usable, because first it will take more space, second all of the
   methods defined on the "Container" struct are based on pointer receiver
   instead of a value receiver. Therefore one had to take the pointer of 
   the returned value to get access to the available methods.

Solution:
1. Return all successful retrieved containers and silently fail for
   failing containers.
2. Return a slice of pointer to containers instead of a slice of value of containers.
