### PR TITLE
lxc_test: change package name to lxc

### DIFF
--- a/lxc_test.go
+++ b/lxc_test.go
@@ -7,7 +7,7 @@
 
 // +build linux
 
-package lxc_test
+package lxc
 
 import (
 	"math/rand"
@@ -18,8 +18,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/lxc/go-lxc"
 )
 
 const (
@@ -43,21 +41,21 @@ func unprivileged() bool {
 }
 
 func TestVersion(t *testing.T) {
-	t.Logf("LXC version: %s", lxc.Version())
+	t.Logf("LXC version: %s", Version())
 }
 
 func TestDefaultConfigPath(t *testing.T) {
-	if lxc.DefaultConfigPath() == "" {
+	if DefaultConfigPath() == "" {
 		t.Errorf("DefaultConfigPath failed...")
 	}
 }
 
 func TestSetConfigPath(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	currentPath := c.ConfigPath()
 	if err := c.SetConfigPath("/tmp"); err != nil {
@@ -71,14 +69,14 @@ func TestSetConfigPath(t *testing.T) {
 }
 
 func TestGetContainer(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
-	lxc.GetContainer(c)
-	lxc.PutContainer(c)
+	GetContainer(c)
+	PutContainer(c)
 }
 
 func TestConcurrentDefined_Negative(t *testing.T) {
@@ -89,11 +87,11 @@ func TestConcurrentDefined_Negative(t *testing.T) {
 	for i := 0; i <= 100; i++ {
 		wg.Add(1)
 		go func() {
-			c, err := lxc.NewContainer(strconv.Itoa(rand.Intn(10)))
+			c, err := NewContainer(strconv.Itoa(rand.Intn(10)))
 			if err != nil {
 				t.Errorf(err.Error())
 			}
-			defer lxc.PutContainer(c)
+			defer PutContainer(c)
 
 			// sleep for a while to simulate some dummy work
 			time.Sleep(time.Millisecond * time.Duration(rand.Intn(250)))
@@ -108,11 +106,11 @@ func TestConcurrentDefined_Negative(t *testing.T) {
 }
 
 func TestDefined_Negative(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if c.Defined() {
 		t.Errorf("Defined_Negative failed...")
@@ -124,11 +122,11 @@ func TestExecute(t *testing.T) {
 		t.Skip("skipping test in unprivileged mode.")
 	}
 
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.Execute("/bin/true"); err != nil {
 		t.Errorf(err.Error())
@@ -136,21 +134,21 @@ func TestExecute(t *testing.T) {
 }
 
 func TestSetVerbosity(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
-	c.SetVerbosity(lxc.Quiet)
+	c.SetVerbosity(Quiet)
 }
 
 func TestCreate(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if unprivileged() {
 		if err := c.CreateAsUser(Distro, Release, Arch); err != nil {
@@ -164,11 +162,11 @@ func TestCreate(t *testing.T) {
 }
 
 func TestClone(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.Clone(ContainerCloneName); err != nil {
 		t.Errorf(err.Error())
@@ -176,13 +174,13 @@ func TestClone(t *testing.T) {
 }
 
 func TestCloneUsingOverlayfs(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
-	if err := c.CloneUsing(ContainerCloneOverlayName, lxc.Overlayfs, lxc.CloneSnapshot|lxc.CloneKeepName|lxc.CloneKeepMACAddr); err != nil {
+	if err := c.CloneUsing(ContainerCloneOverlayName, Overlayfs, CloneSnapshot|CloneKeepName|CloneKeepMACAddr); err != nil {
 		t.Errorf(err.Error())
 	}
 }
@@ -192,23 +190,23 @@ func TestCloneUsingAufs(t *testing.T) {
 		t.Skip("skipping test in unprivileged mode.")
 	}
 
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
-	if err := c.CloneUsing(ContainerCloneAufsName, lxc.Aufs, lxc.CloneSnapshot|lxc.CloneKeepName|lxc.CloneKeepMACAddr); err != nil {
+	if err := c.CloneUsing(ContainerCloneAufsName, Aufs, CloneSnapshot|CloneKeepName|CloneKeepMACAddr); err != nil {
 		t.Errorf(err.Error())
 	}
 }
 
 func TestCreateSnapshot(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.CreateSnapshot(); err != nil {
 		t.Errorf(err.Error())
@@ -216,13 +214,13 @@ func TestCreateSnapshot(t *testing.T) {
 }
 
 func TestRestoreSnapshot(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
-	snapshot := lxc.Snapshot{Name: SnapshotName}
+	snapshot := Snapshot{Name: SnapshotName}
 	if err := c.RestoreSnapshot(snapshot, ContainerRestoreName); err != nil {
 		t.Errorf(err.Error())
 	}
@@ -240,11 +238,11 @@ func TestConcurrentCreate(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func(i int) {
-			c, err := lxc.NewContainer(strconv.Itoa(i))
+			c, err := NewContainer(strconv.Itoa(i))
 			if err != nil {
 				t.Errorf(err.Error())
 			}
-			defer lxc.PutContainer(c)
+			defer PutContainer(c)
 
 			// sleep for a while to simulate some dummy work
 			time.Sleep(time.Millisecond * time.Duration(rand.Intn(250)))
@@ -259,11 +257,11 @@ func TestConcurrentCreate(t *testing.T) {
 }
 
 func TestSnapshots(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.Snapshots(); err != nil {
 		t.Errorf(err.Error())
@@ -282,17 +280,17 @@ func TestConcurrentStart(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func(i int) {
-			c, err := lxc.NewContainer(strconv.Itoa(i))
+			c, err := NewContainer(strconv.Itoa(i))
 			if err != nil {
 				t.Errorf(err.Error())
 			}
-			defer lxc.PutContainer(c)
+			defer PutContainer(c)
 
 			if err := c.Start(); err != nil {
 				t.Errorf(err.Error())
 			}
 
-			c.Wait(lxc.RUNNING, 30)
+			c.Wait(RUNNING, 30)
 			if !c.Running() {
 				t.Errorf("Starting the container failed...")
 			}
@@ -304,11 +302,11 @@ func TestConcurrentStart(t *testing.T) {
 }
 
 func TestConfigFileName(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if c.ConfigFileName() == "" {
 		t.Errorf("ConfigFileName failed...")
@@ -316,11 +314,11 @@ func TestConfigFileName(t *testing.T) {
 }
 
 func TestDefined_Positive(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if !c.Defined() {
 		t.Errorf("Defined_Positive failed...")
@@ -339,11 +337,11 @@ func TestConcurrentDefined_Positive(t *testing.T) {
 	for i := 0; i <= 100; i++ {
 		wg.Add(1)
 		go func() {
-			c, err := lxc.NewContainer(strconv.Itoa(rand.Intn(10)))
+			c, err := NewContainer(strconv.Itoa(rand.Intn(10)))
 			if err != nil {
 				t.Errorf(err.Error())
 			}
-			defer lxc.PutContainer(c)
+			defer PutContainer(c)
 
 			// sleep for a while to simulate some dummy work
 			time.Sleep(time.Millisecond * time.Duration(rand.Intn(250)))
@@ -358,11 +356,11 @@ func TestConcurrentDefined_Positive(t *testing.T) {
 }
 
 func TestInitPid_Negative(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if c.InitPid() != -1 {
 		t.Errorf("InitPid failed...")
@@ -370,28 +368,28 @@ func TestInitPid_Negative(t *testing.T) {
 }
 
 func TestStart(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.Start(); err != nil {
 		t.Errorf(err.Error())
 	}
 
-	c.Wait(lxc.RUNNING, 30)
+	c.Wait(RUNNING, 30)
 	if !c.Running() {
 		t.Errorf("Starting the container failed...")
 	}
 }
 
 func TestControllable(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if !c.Controllable() {
 		t.Errorf("Controling the container failed...")
@@ -399,47 +397,47 @@ func TestControllable(t *testing.T) {
 }
 
 func TestContainerNames(t *testing.T) {
-	if lxc.ContainerNames() == nil {
+	if ContainerNames() == nil {
 		t.Errorf("ContainerNames failed...")
 	}
 }
 
 func TestDefinedContainerNames(t *testing.T) {
-	if lxc.DefinedContainerNames() == nil {
+	if DefinedContainerNames() == nil {
 		t.Errorf("DefinedContainerNames failed...")
 	}
 }
 
 func TestActiveContainerNames(t *testing.T) {
-	if lxc.ActiveContainerNames() == nil {
+	if ActiveContainerNames() == nil {
 		t.Errorf("ActiveContainerNames failed...")
 	}
 }
 
 func TestContainers(t *testing.T) {
-	if lxc.Containers() == nil {
+	if Containers() == nil {
 		t.Errorf("Containers failed...")
 	}
 }
 
 func TestDefinedContainers(t *testing.T) {
-	if lxc.DefinedContainers() == nil {
+	if DefinedContainers() == nil {
 		t.Errorf("DefinedContainers failed...")
 	}
 }
 
 func TestActiveContainers(t *testing.T) {
-	if lxc.ActiveContainers() == nil {
+	if ActiveContainers() == nil {
 		t.Errorf("ActiveContainers failed...")
 	}
 }
 
 func TestRunning(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if !c.Running() {
 		t.Errorf("Checking the container failed...")
@@ -447,11 +445,11 @@ func TestRunning(t *testing.T) {
 }
 
 func TestWantDaemonize(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.WantDaemonize(false); err != nil || c.Daemonize() {
 		t.Errorf("WantDaemonize failed...")
@@ -459,11 +457,11 @@ func TestWantDaemonize(t *testing.T) {
 }
 
 func TestWantCloseAllFds(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.WantCloseAllFds(true); err != nil {
 		t.Errorf("WantCloseAllFds failed...")
@@ -471,23 +469,23 @@ func TestWantCloseAllFds(t *testing.T) {
 }
 
 func TestSetLogLevel(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
-	if err := c.SetLogLevel(lxc.WARN); err != nil || c.LogLevel() != lxc.WARN {
+	if err := c.SetLogLevel(WARN); err != nil || c.LogLevel() != WARN {
 		t.Errorf("SetLogLevel( failed...")
 	}
 }
 
 func TestSetLogFile(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.SetLogFile("/tmp/" + ContainerName); err != nil || c.LogFile() != "/tmp/"+ContainerName {
 		t.Errorf("SetLogFile failed...")
@@ -495,11 +493,11 @@ func TestSetLogFile(t *testing.T) {
 }
 
 func TestInitPid_Positive(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if c.InitPid() == -1 {
 		t.Errorf("InitPid failed...")
@@ -507,11 +505,11 @@ func TestInitPid_Positive(t *testing.T) {
 }
 
 func TestName(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if c.Name() != ContainerName {
 		t.Errorf("Name failed...")
@@ -519,45 +517,45 @@ func TestName(t *testing.T) {
 }
 
 func TestFreeze(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.Freeze(); err != nil {
 		t.Errorf(err.Error())
 	}
 
-	c.Wait(lxc.FROZEN, 30)
-	if c.State() != lxc.FROZEN {
+	c.Wait(FROZEN, 30)
+	if c.State() != FROZEN {
 		t.Errorf("Freezing the container failed...")
 	}
 }
 
 func TestUnfreeze(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.Unfreeze(); err != nil {
 		t.Errorf(err.Error())
 	}
 
-	c.Wait(lxc.RUNNING, 30)
+	c.Wait(RUNNING, 30)
 	if !c.Running() {
 		t.Errorf("Unfreezing the container failed...")
 	}
 }
 
 func TestLoadConfigFile(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.LoadConfigFile(c.ConfigFileName()); err != nil {
 		t.Errorf(err.Error())
@@ -565,11 +563,11 @@ func TestLoadConfigFile(t *testing.T) {
 }
 
 func TestSaveConfigFile(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.SaveConfigFile(c.ConfigFileName()); err != nil {
 		t.Errorf(err.Error())
@@ -577,11 +575,11 @@ func TestSaveConfigFile(t *testing.T) {
 }
 
 func TestConfigItem(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if c.ConfigItem("lxc.utsname")[0] != ContainerName {
 		t.Errorf("ConfigItem failed...")
@@ -589,11 +587,11 @@ func TestConfigItem(t *testing.T) {
 }
 
 func TestSetConfigItem(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.SetConfigItem("lxc.utsname", ContainerName); err != nil {
 		t.Errorf(err.Error())
@@ -605,11 +603,11 @@ func TestSetConfigItem(t *testing.T) {
 }
 
 func TestRunningConfigItem(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if c.RunningConfigItem("lxc.network.0.type") == nil {
 		t.Errorf("RunningConfigItem failed...")
@@ -617,11 +615,11 @@ func TestRunningConfigItem(t *testing.T) {
 }
 
 func TestSetCgroupItem(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	maxMem := c.CgroupItem("memory.max_usage_in_bytes")[0]
 	currentMem := c.CgroupItem("memory.limit_in_bytes")[0]
@@ -636,11 +634,11 @@ func TestSetCgroupItem(t *testing.T) {
 }
 
 func TestClearConfigItem(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.ClearConfigItem("lxc.cap.drop"); err != nil {
 		t.Errorf(err.Error())
@@ -651,11 +649,11 @@ func TestClearConfigItem(t *testing.T) {
 }
 
 func TestConfigKeys(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	keys := strings.Join(c.ConfigKeys("lxc.network.0"), " ")
 	if !strings.Contains(keys, "mtu") {
@@ -664,11 +662,11 @@ func TestConfigKeys(t *testing.T) {
 }
 
 func TestInterfaces(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.Interfaces(); err != nil {
 		t.Errorf(err.Error())
@@ -676,11 +674,11 @@ func TestInterfaces(t *testing.T) {
 }
 
 func TestMemoryUsage(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.MemoryUsage(); err != nil {
 		t.Errorf(err.Error())
@@ -688,11 +686,11 @@ func TestMemoryUsage(t *testing.T) {
 }
 
 func TestKernelMemoryUsage(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.KernelMemoryUsage(); err != nil {
 		t.Errorf(err.Error())
@@ -700,11 +698,11 @@ func TestKernelMemoryUsage(t *testing.T) {
 }
 
 func TestMemorySwapUsage(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.MemorySwapUsage(); err != nil {
 		t.Errorf(err.Error())
@@ -712,11 +710,11 @@ func TestMemorySwapUsage(t *testing.T) {
 }
 
 func TestBlkioUsage(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.BlkioUsage(); err != nil {
 		t.Errorf(err.Error())
@@ -724,11 +722,11 @@ func TestBlkioUsage(t *testing.T) {
 }
 
 func TestMemoryLimit(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.MemoryLimit(); err != nil {
 		t.Errorf(err.Error())
@@ -736,11 +734,11 @@ func TestMemoryLimit(t *testing.T) {
 }
 
 func TestKernelMemoryLimit(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.KernelMemoryLimit(); err != nil {
 		t.Errorf(err.Error())
@@ -748,11 +746,11 @@ func TestKernelMemoryLimit(t *testing.T) {
 }
 
 func TestMemorySwapLimit(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.MemorySwapLimit(); err != nil {
 		t.Errorf(err.Error())
@@ -760,11 +758,11 @@ func TestMemorySwapLimit(t *testing.T) {
 }
 
 func TestSetMemoryLimit(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	oldMemLimit, _ := c.MemoryLimit()
 
@@ -781,11 +779,11 @@ func TestSetMemoryLimit(t *testing.T) {
 func TestSetKernelMemoryLimit(t *testing.T) {
 	t.Skip("skipping test")
 
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	oldMemLimit, _ := c.KernelMemoryLimit()
 	if err := c.SetKernelMemoryLimit(oldMemLimit * 4); err != nil {
@@ -799,11 +797,11 @@ func TestSetKernelMemoryLimit(t *testing.T) {
 }
 
 func TestSetMemorySwapLimit(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	oldMemorySwapLimit, _ := c.MemorySwapLimit()
 
@@ -818,11 +816,11 @@ func TestSetMemorySwapLimit(t *testing.T) {
 }
 
 func TestCPUTime(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.CPUTime(); err != nil {
 		t.Errorf(err.Error())
@@ -830,11 +828,11 @@ func TestCPUTime(t *testing.T) {
 }
 
 func TestCPUTimePerCPU(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.CPUTimePerCPU(); err != nil {
 		t.Errorf(err.Error())
@@ -842,11 +840,11 @@ func TestCPUTimePerCPU(t *testing.T) {
 }
 
 func TestCPUStats(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.CPUStats(); err != nil {
 		t.Errorf(err.Error())
@@ -854,11 +852,11 @@ func TestCPUStats(t *testing.T) {
 }
 
 func TestRunCommand(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	argsThree := []string{"/bin/sh", "-c", "/bin/ls -al > /dev/null"}
 	if err := c.RunCommand(os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd(), argsThree...); err != nil {
@@ -867,11 +865,11 @@ func TestRunCommand(t *testing.T) {
 }
 
 func TestRunCommandWithClearEnvironment(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	argsThree := []string{"/bin/sh", "-c", "/bin/ls -al > /dev/null"}
 	if err := c.RunCommandWithClearEnvironment(os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd(), argsThree...); err != nil {
@@ -880,11 +878,11 @@ func TestRunCommandWithClearEnvironment(t *testing.T) {
 }
 
 func TestConsoleFd(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.ConsoleFd(0); err != nil {
 		t.Errorf(err.Error())
@@ -892,11 +890,11 @@ func TestConsoleFd(t *testing.T) {
 }
 
 func TestIPAddress(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.IPAddress("lo"); err != nil {
 		t.Errorf(err.Error())
@@ -908,11 +906,11 @@ func TestAddDeviceNode(t *testing.T) {
 		t.Skip("skipping test in unprivileged mode.")
 	}
 
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.AddDeviceNode("/dev/network_latency"); err != nil {
 		t.Errorf(err.Error())
@@ -924,11 +922,11 @@ func TestRemoveDeviceNode(t *testing.T) {
 		t.Skip("skipping test in unprivileged mode.")
 	}
 
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.RemoveDeviceNode("/dev/network_latency"); err != nil {
 		t.Errorf(err.Error())
@@ -938,11 +936,11 @@ func TestRemoveDeviceNode(t *testing.T) {
 func TestIPv4Addresses(t *testing.T) {
 	t.Skip("skipping test")
 
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.IPv4Addresses(); err != nil {
 		t.Errorf(err.Error())
@@ -952,11 +950,11 @@ func TestIPv4Addresses(t *testing.T) {
 func TestIPv6Addresses(t *testing.T) {
 	t.Skip("skipping test")
 
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if _, err := c.IPv6Addresses(); err != nil {
 		t.Errorf(err.Error())
@@ -964,16 +962,16 @@ func TestIPv6Addresses(t *testing.T) {
 }
 
 func TestReboot(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.Reboot(); err != nil {
 		t.Errorf("Rebooting the container failed...")
 	}
-	c.Wait(lxc.RUNNING, 30)
+	c.Wait(RUNNING, 30)
 }
 
 func TestConcurrentShutdown(t *testing.T) {
@@ -988,17 +986,17 @@ func TestConcurrentShutdown(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func(i int) {
-			c, err := lxc.NewContainer(strconv.Itoa(i))
+			c, err := NewContainer(strconv.Itoa(i))
 			if err != nil {
 				t.Errorf(err.Error())
 			}
-			defer lxc.PutContainer(c)
+			defer PutContainer(c)
 
 			if err := c.Shutdown(30); err != nil {
 				t.Errorf(err.Error())
 			}
 
-			c.Wait(lxc.STOPPED, 30)
+			c.Wait(STOPPED, 30)
 			if c.Running() {
 				t.Errorf("Shutting down the container failed...")
 			}
@@ -1010,28 +1008,28 @@ func TestConcurrentShutdown(t *testing.T) {
 }
 
 func TestShutdown(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.Shutdown(30); err != nil {
 		t.Errorf(err.Error())
 	}
 
-	c.Wait(lxc.STOPPED, 30)
+	c.Wait(STOPPED, 30)
 	if c.Running() {
 		t.Errorf("Shutting down the container failed...")
 	}
 }
 
 func TestStop(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.Start(); err != nil {
 		t.Errorf(err.Error())
@@ -1041,73 +1039,73 @@ func TestStop(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	c.Wait(lxc.STOPPED, 30)
+	c.Wait(STOPPED, 30)
 	if c.Running() {
 		t.Errorf("Stopping the container failed...")
 	}
 }
 
 func TestDestroySnapshot(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerName)
+	c, err := NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
-	snapshot := lxc.Snapshot{Name: SnapshotName}
+	snapshot := Snapshot{Name: SnapshotName}
 	if err := c.DestroySnapshot(snapshot); err != nil {
 		t.Errorf(err.Error())
 	}
 }
 
 func TestDestroy(t *testing.T) {
-	c, err := lxc.NewContainer(ContainerCloneOverlayName)
+	c, err := NewContainer(ContainerCloneOverlayName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.Destroy(); err != nil {
 		t.Errorf(err.Error())
 	}
 
 	if !unprivileged() {
-		c, err = lxc.NewContainer(ContainerCloneAufsName)
+		c, err = NewContainer(ContainerCloneAufsName)
 		if err != nil {
 			t.Errorf(err.Error())
 		}
-		defer lxc.PutContainer(c)
+		defer PutContainer(c)
 
 		if err := c.Destroy(); err != nil {
 			t.Errorf(err.Error())
 		}
 	}
 
-	c, err = lxc.NewContainer(ContainerCloneName)
+	c, err = NewContainer(ContainerCloneName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.Destroy(); err != nil {
 		t.Errorf(err.Error())
 	}
 
-	c, err = lxc.NewContainer(ContainerRestoreName)
+	c, err = NewContainer(ContainerRestoreName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.Destroy(); err != nil {
 		t.Errorf(err.Error())
 	}
 
-	c, err = lxc.NewContainer(ContainerName)
+	c, err = NewContainer(ContainerName)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer lxc.PutContainer(c)
+	defer PutContainer(c)
 
 	if err := c.Destroy(); err != nil {
 		t.Errorf(err.Error())
@@ -1126,11 +1124,11 @@ func TestConcurrentDestroy(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func(i int) {
-			c, err := lxc.NewContainer(strconv.Itoa(i))
+			c, err := NewContainer(strconv.Itoa(i))
 			if err != nil {
 				t.Errorf(err.Error())
 			}
-			defer lxc.PutContainer(c)
+			defer PutContainer(c)
 
 			// sleep for a while to simulate some dummy work
 			time.Sleep(time.Millisecond * time.Duration(rand.Intn(250)))


### PR DESCRIPTION
**Problem**: they are different ways of declaring a package name for
testing. Usually the package name of tests are the same as the base
package name (in our case "lxc"). However some libraries (including Go's
std libraries) is using the abbrv: "foo_test" for the package name of
tests. This has the caveat that it's not possible to access to the
package's private identifiers. For more information see:
http://stackoverflow.com/questions/19998250/proper-package-naming-for-testing-in-go-lang

**Solution**: this fixes #3 by changing the package name from "lxc_test" to
"lxc".
