### PR TITLE
type: enable zero value for BackendStore

### DIFF
--- a/lxc_test.go
+++ b/lxc_test.go
@@ -1220,3 +1220,23 @@ func TestConcurrentDestroy(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestBackendStore(t *testing.T) {
+	var X struct {
+		store BackendStore
+	}
+
+	if X.store.String() != "<INVALID>" {
+		t.Error("zero value of BackendStore should be invalid")
+	}
+}
+
+func TestState(t *testing.T) {
+	var X struct {
+		state State
+	}
+
+	if X.state.String() != "<INVALID>" {
+		t.Error("zero value of State should be invalid")
+	}
+}

--- a/type.go
+++ b/type.go
@@ -31,7 +31,7 @@ type BackendStore int
 
 const (
 	// Btrfs backendstore type
-	Btrfs BackendStore = iota
+	Btrfs BackendStore = iota + 1
 	// Directory backendstore type
 	Directory
 	// LVM backendstore type
@@ -76,7 +76,7 @@ type State int
 
 const (
 	// STOPPED means container is not running
-	STOPPED State = iota
+	STOPPED State = iota + 1
 	// STARTING means container is starting
 	STARTING
 	// RUNNING means container is running


### PR DESCRIPTION
Problem: There is no way one can identify if a BackendStore is
uninitialized (a.k.a has zero value) or initialized. It always will
return the type `Btrfs`. Also the `String()` method never will return the
string `<INVALID>`

Solution: Increase the enum just one by one. This will make
uninitialized values of BackendStore as 0. One can then check easily
with:

```
store := BackendStore

if store == 0 {
    // uninitialized
}
```

Also the `String()` methods is going to return the `<INVALID>` string.
