### PR TITLE
Return boolean success status from RunCommand*

### DIFF
--- a/container.go
+++ b/container.go
@@ -992,28 +992,8 @@ func (c *Container) AttachShellWithClearEnvironment() error {
 // stdinfd: fd to read input from
 // stdoutfd: fd to write output to
 // stderrfd: fd to write error output to
-func (c *Container) RunCommand(stdinfd, stdoutfd, stderrfd uintptr, args ...string) error {
-	if args == nil {
-		return ErrInsufficientNumberOfArguments
-	}
-
-	if err := c.makeSure(isDefined | isRunning); err != nil {
-		return err
-	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	cargs := makeNullTerminatedArgs(args)
-	if cargs == nil {
-		return ErrAllocationFailed
-	}
-	defer freeNullTerminatedArgs(cargs, len(args))
-
-	if int(C.go_lxc_attach_run_wait(c.container, false, C.int(stdinfd), C.int(stdoutfd), C.int(stderrfd), cargs)) < 0 {
-		return ErrAttachFailed
-	}
-	return nil
+func (c *Container) RunCommand(stdinfd, stdoutfd, stderrfd uintptr, args ...string) (bool, error) {
+	return c.runCommand(stdinfd, stdoutfd, stderrfd, false, args...)
 }
 
 // RunCommandWithClearEnvironment runs the user specified command inside the container
@@ -1021,13 +1001,17 @@ func (c *Container) RunCommand(stdinfd, stdoutfd, stderrfd uintptr, args ...stri
 // stdinfd: fd to read input from
 // stdoutfd: fd to write output to
 // stderrfd: fd to write error output to
-func (c *Container) RunCommandWithClearEnvironment(stdinfd, stdoutfd, stderrfd uintptr, args ...string) error {
+func (c *Container) RunCommandWithClearEnvironment(stdinfd, stdoutfd, stderrfd uintptr, args ...string) (bool, error) {
+	return c.runCommand(stdinfd, stdoutfd, stderrfd, true, args...)
+}
+
+func (c *Container) runCommand(stdinfd, stdoutfd, stderrfd uintptr, clearenv bool, args ...string) (bool, error) {
 	if args == nil {
-		return ErrInsufficientNumberOfArguments
+		return false, ErrInsufficientNumberOfArguments
 	}
 
 	if err := c.makeSure(isDefined | isRunning); err != nil {
-		return err
+		return false, err
 	}
 
 	c.mu.Lock()
@@ -1035,14 +1019,16 @@ func (c *Container) RunCommandWithClearEnvironment(stdinfd, stdoutfd, stderrfd u
 
 	cargs := makeNullTerminatedArgs(args)
 	if cargs == nil {
-		return ErrAllocationFailed
+		return false, ErrAllocationFailed
 	}
 	defer freeNullTerminatedArgs(cargs, len(args))
 
-	if int(C.go_lxc_attach_run_wait(c.container, true, C.int(stdinfd), C.int(stdoutfd), C.int(stderrfd), cargs)) < 0 {
-		return ErrAttachFailed
+	ret := int(C.go_lxc_attach_run_wait(c.container, C.bool(clearenv), C.int(stdinfd), C.int(stdoutfd), C.int(stderrfd), cargs))
+
+	if ret < 0 {
+		return false, ErrAttachFailed
 	}
-	return nil
+	return ret == 0, nil
 }
 
 // Interfaces returns the names of the network interfaces.

--- a/examples/attach.go
+++ b/examples/attach.go
@@ -57,7 +57,7 @@ func main() {
 		}
 
 		log.Printf("RunCommandWithClearEnvironment\n")
-		if err := c.RunCommandWithClearEnvironment(os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd(), "uname", "-a"); err != nil {
+		if _, err := c.RunCommandWithClearEnvironment(os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd(), "uname", "-a"); err != nil {
 			log.Fatalf("ERROR: %s\n", err.Error())
 		}
 
@@ -68,7 +68,7 @@ func main() {
 		}
 
 		log.Printf("RunCommand\n")
-		if err := c.RunCommand(os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd(), "uname", "-a"); err != nil {
+		if _, err := c.RunCommand(os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd(), "uname", "-a"); err != nil {
 			log.Fatalf("ERROR: %s\n", err.Error())
 		}
 	}

--- a/examples/attach_with_pipes.go
+++ b/examples/attach_with_pipes.go
@@ -87,7 +87,7 @@ func main() {
 		}
 
 		log.Printf("RunCommandWithClearEnvironment\n")
-		if err := c.RunCommandWithClearEnvironment(os.Stdin.Fd(), stdoutWriter.Fd(), stderrWriter.Fd(), "uname", "-a"); err != nil {
+		if _, err := c.RunCommandWithClearEnvironment(os.Stdin.Fd(), stdoutWriter.Fd(), stderrWriter.Fd(), "uname", "-a"); err != nil {
 			log.Fatalf("ERROR: %s\n", err.Error())
 		}
 	} else {
@@ -97,7 +97,7 @@ func main() {
 		}
 
 		log.Printf("RunCommand\n")
-		if err := c.RunCommand(os.Stdin.Fd(), stdoutWriter.Fd(), stderrWriter.Fd(), "uname", "-a"); err != nil {
+		if _, err := c.RunCommand(os.Stdin.Fd(), stdoutWriter.Fd(), stderrWriter.Fd(), "uname", "-a"); err != nil {
 			log.Fatalf("ERROR: %s\n", err.Error())
 		}
 	}

--- a/lxc_test.go
+++ b/lxc_test.go
@@ -933,8 +933,21 @@ func TestRunCommand(t *testing.T) {
 	defer PutContainer(c)
 
 	argsThree := []string{"/bin/sh", "-c", "/bin/ls -al > /dev/null"}
-	if err := c.RunCommand(os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd(), argsThree...); err != nil {
+	ok, err := c.RunCommand(os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd(), argsThree...)
+	if err != nil {
 		t.Errorf(err.Error())
+	}
+	if ok != true {
+		t.Errorf("Expected success")
+	}
+
+	argsThree = []string{"/bin/sh", "-c", "exit 1"}
+	ok, err = c.RunCommand(os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd(), argsThree...)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if ok != false {
+		t.Errorf("Expected failure")
 	}
 }
 
@@ -946,8 +959,21 @@ func TestRunCommandWithClearEnvironment(t *testing.T) {
 	defer PutContainer(c)
 
 	argsThree := []string{"/bin/sh", "-c", "/bin/ls -al > /dev/null"}
-	if err := c.RunCommandWithClearEnvironment(os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd(), argsThree...); err != nil {
+	ok, err := c.RunCommandWithClearEnvironment(os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd(), argsThree...)
+	if err != nil {
 		t.Errorf(err.Error())
+	}
+	if ok != true {
+		t.Errorf("Expected success")
+	}
+
+	argsThree = []string{"/bin/sh", "-c", "exit 1"}
+	ok, err = c.RunCommandWithClearEnvironment(os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd(), argsThree...)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if ok != false {
+		t.Errorf("Expected failure")
 	}
 }
 


### PR DESCRIPTION
This adjusts the signature of RunCommand and RunCommandWithClearEnvironment to return (bool, error), where the boolean indicates whether the underlying command exited with a successful status code.

Refs GH-9
