### PR TITLE
WIP: Allow configuration of attach_options (env, cwd)

### DIFF
--- a/lxc.c
+++ b/lxc.c
@@ -183,13 +183,13 @@ char** go_lxc_get_ips(struct lxc_container *c, const char *interface, const char
 int go_lxc_attach(struct lxc_container *c, bool clear_env) {
 	int ret;
 	pid_t pid;
+
 	lxc_attach_options_t attach_options = LXC_ATTACH_OPTIONS_DEFAULT;
 
 	attach_options.env_policy = LXC_ATTACH_KEEP_ENV;
 	if (clear_env) {
 		attach_options.env_policy = LXC_ATTACH_CLEAR_ENV;
 	}
-
 	/*
 	   remount_sys_proc
 	   When using -s and the mount namespace is not included, this flag will cause lxc-attach to remount /proc and /sys to reflect the current other namespace contexts.
@@ -228,8 +228,9 @@ int go_lxc_attach(struct lxc_container *c, bool clear_env) {
 	return -1;
 }
 
-int go_lxc_attach_run_wait(struct lxc_container *c, bool clear_env, int stdinfd, int stdoutfd, int stderrfd, const char * const argv[]) {
+int go_lxc_attach_run_wait(struct lxc_container *c, bool clear_env, int stdinfd, int stdoutfd, int stderrfd, char *initial_cwd, char *extra_env_vars[], const char * const argv[]) {
 	int ret;
+
 	lxc_attach_options_t attach_options = LXC_ATTACH_OPTIONS_DEFAULT;
 
 	attach_options.env_policy = LXC_ATTACH_KEEP_ENV;
@@ -239,6 +240,8 @@ int go_lxc_attach_run_wait(struct lxc_container *c, bool clear_env, int stdinfd,
 	attach_options.stdin_fd = stdinfd;
 	attach_options.stdout_fd = stdoutfd;
 	attach_options.stderr_fd = stderrfd;
+	attach_options.initial_cwd = initial_cwd;
+	attach_options.extra_env_vars = extra_env_vars;
 
 	ret = c->attach_run_wait(c, &attach_options, argv[0], argv);
 	if (WIFEXITED(ret) && WEXITSTATUS(ret) == 255)

--- a/lxc.h
+++ b/lxc.h
@@ -42,7 +42,7 @@ extern char* go_lxc_get_keys(struct lxc_container *c, const char *key);
 extern char* go_lxc_get_running_config_item(struct lxc_container *c, const char *key);
 extern const char* go_lxc_get_config_path(struct lxc_container *c);
 extern const char* go_lxc_state(struct lxc_container *c);
-extern int go_lxc_attach_run_wait(struct lxc_container *c, bool clear_env, int stdinfd, int stdoutfd, int stderrfd, const char * const argv[]);
+extern int go_lxc_attach_run_wait(struct lxc_container *c, bool clear_env, int stdinfd, int stdoutfd, int stderrfd, char initial_cwd, char extra_env_vars[], const char * const argv[]);
 extern int go_lxc_attach(struct lxc_container *c, bool clear_env);
 extern int go_lxc_console_getfd(struct lxc_container *c, int ttynum);
 extern int go_lxc_snapshot_list(struct lxc_container *c, struct lxc_snapshot **ret);

--- a/lxc_test.go
+++ b/lxc_test.go
@@ -977,6 +977,56 @@ func TestRunCommandWithClearEnvironment(t *testing.T) {
 	}
 }
 
+func TestCommandWithEnvVars(t *testing.T) {
+	c, err := NewContainer(ContainerName)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	defer PutContainer(c)
+
+	cmd := &Command{
+		Args: []string{"/bin/sh", "-c", "test $FOO = 'BAR'"},
+		Env: []string{"FOO=BAR"},
+		ClearEnv: true,
+		Stdinfd: os.Stdin.Fd(),
+		Stdoutfd: os.Stdout.Fd(),
+		Stderrfd: os.Stderr.Fd(),
+	}
+	ok, err := cmd.Run(c)
+
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if ok != true {
+		t.Errorf("Expected success")
+	}
+}
+
+func TestCommandWithCwd(t *testing.T) {
+	c, err := NewContainer(ContainerName)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	defer PutContainer(c)
+
+	cmd := &Command{
+		Args: []string{"/bin/sh", "-c", "test `pwd` = /tmp"},
+		ClearEnv: true,
+		Stdinfd: os.Stdin.Fd(),
+		Stdoutfd: os.Stdout.Fd(),
+		Stderrfd: os.Stderr.Fd(),
+		Cwd: "/tmp",
+	}
+	ok, err := cmd.Run(c)
+
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if ok != true {
+		t.Errorf("Expected success")
+	}
+}
+
 func TestConsoleFd(t *testing.T) {
 	c, err := NewContainer(ContainerName)
 	if err != nil {


### PR DESCRIPTION
This isn't complete, but I'm interested to hear feedback. Creating the Command struct was the cleanest way I could see to introduce this without adding a lot of extra complexity (and without butchering the existing APIs).

See the included tests for usage, but the gist is:

``` go
cmd := &Command{
    Args: []string{"/bin/sh", "-c", "exit 0"},
    Cwd: "/tmp",
    Env: []string{"FOO=BAR"},
    ClearEnv: true,
}
cmd.Run(container)
```

This extends the existing patch in GH-10
