### PR TITLE
Support AttachOptions via new RunCommand

### DIFF
--- a/lxc.c
+++ b/lxc.c
@@ -4,6 +4,7 @@
 //
 // Authors:
 // S.Çağlar Onur <caglar@10ur.org>
+// David Cramer <dcramer@gmail.com>
 
 // +build linux
 
@@ -183,13 +184,13 @@ char** go_lxc_get_ips(struct lxc_container *c, const char *interface, const char
 int go_lxc_attach(struct lxc_container *c, bool clear_env) {
 	int ret;
 	pid_t pid;
+
 	lxc_attach_options_t attach_options = LXC_ATTACH_OPTIONS_DEFAULT;
 
 	attach_options.env_policy = LXC_ATTACH_KEEP_ENV;
 	if (clear_env) {
 		attach_options.env_policy = LXC_ATTACH_CLEAR_ENV;
 	}
-
 	/*
 	   remount_sys_proc
 	   When using -s and the mount namespace is not included, this flag will cause lxc-attach to remount /proc and /sys to reflect the current other namespace contexts.
@@ -228,8 +229,9 @@ int go_lxc_attach(struct lxc_container *c, bool clear_env) {
 	return -1;
 }
 
-int go_lxc_attach_run_wait(struct lxc_container *c, bool clear_env, int stdinfd, int stdoutfd, int stderrfd, const char * const argv[]) {
+int go_lxc_attach_run_wait(struct lxc_container *c, bool clear_env, int stdinfd, int stdoutfd, int stderrfd, char *initial_cwd, char **extra_env_vars, const char * const argv[]) {
 	int ret;
+
 	lxc_attach_options_t attach_options = LXC_ATTACH_OPTIONS_DEFAULT;
 
 	attach_options.env_policy = LXC_ATTACH_KEEP_ENV;
@@ -239,6 +241,8 @@ int go_lxc_attach_run_wait(struct lxc_container *c, bool clear_env, int stdinfd,
 	attach_options.stdin_fd = stdinfd;
 	attach_options.stdout_fd = stdoutfd;
 	attach_options.stderr_fd = stderrfd;
+	attach_options.initial_cwd = initial_cwd;
+	attach_options.extra_env_vars = extra_env_vars;
 
 	ret = c->attach_run_wait(c, &attach_options, argv[0], argv);
 	if (WIFEXITED(ret) && WEXITSTATUS(ret) == 255)

--- a/lxc.h
+++ b/lxc.h
@@ -4,6 +4,7 @@
 //
 // Authors:
 // S.Çağlar Onur <caglar@10ur.org>
+// David Cramer <dcramer@gmail.com>
 
 extern bool go_lxc_add_device_node(struct lxc_container *c, const char *src_path, const char *dest_path);
 extern void go_lxc_clear_config(struct lxc_container *c);
@@ -42,7 +43,7 @@ extern char* go_lxc_get_keys(struct lxc_container *c, const char *key);
 extern char* go_lxc_get_running_config_item(struct lxc_container *c, const char *key);
 extern const char* go_lxc_get_config_path(struct lxc_container *c);
 extern const char* go_lxc_state(struct lxc_container *c);
-extern int go_lxc_attach_run_wait(struct lxc_container *c, bool clear_env, int stdinfd, int stdoutfd, int stderrfd, const char * const argv[]);
+extern int go_lxc_attach_run_wait(struct lxc_container *c, bool clear_env, int stdinfd, int stdoutfd, int stderrfd, char *initial_cwd, char **extra_env_vars, const char * const argv[]);
 extern int go_lxc_attach(struct lxc_container *c, bool clear_env);
 extern int go_lxc_console_getfd(struct lxc_container *c, int ttynum);
 extern int go_lxc_snapshot_list(struct lxc_container *c, struct lxc_snapshot **ret);

--- a/options.go
+++ b/options.go
@@ -1,0 +1,32 @@
+// Copyright © 2013, 2014, S.Çağlar Onur
+// Use of this source code is governed by a LGPLv2.1
+// license that can be found in the LICENSE file.
+//
+// Authors:
+// S.Çağlar Onur <caglar@10ur.org>
+// David Cramer <dcramer@gmail.com>
+
+// +build linux
+
+package lxc
+
+type AttachOptions struct {
+	// Stdinfd specifies the fd to read input from
+	Stdinfd uintptr
+
+	// Stdoutfd specifies the fd to write output to
+	Stdoutfd uintptr
+
+	// Stderrfd specifies the fd to write error output to
+	Stderrfd uintptr
+
+	// Env specifies the environment of the process.
+	Env []string
+
+	// Cwd specifies the working directory of the command.
+	Cwd string
+
+	// If ClearEnv is true the environment is cleared before
+	// running the command.
+	ClearEnv bool
+}


### PR DESCRIPTION
Fixes GH-12

``` go
c.RunCommand([]string{"/bin/sh", "ls"}, &AttachOptions{
    Stdinfd: os.Stdin.Fd(),
    Stdoutfd: os.Stdout.Fd(),
    Stderrfd: os.Stderr.Fd(),
    Cwd: "/tmp",
    Env: []string{"FOO=BAR"},
})
```

This additionally removes RunCommandWithClearEnv as it's not longer obviously useful.
