### PR TITLE
Expose StateMap to users of the binding

### DIFF
--- a/container.go
+++ b/container.go
@@ -210,7 +210,7 @@ func (c *Container) State() State {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return stateMap[C.GoString(C.go_lxc_state(c.container))]
+	return StateMap[C.GoString(C.go_lxc_state(c.container))]
 }
 
 // InitPid returns the process ID of the container's init process

--- a/type.go
+++ b/type.go
@@ -109,7 +109,7 @@ const (
 	THAWED
 )
 
-var stateMap = map[string]State{
+var StateMap = map[string]State{
 	"STOPPED":  STOPPED,
 	"STARTING": STARTING,
 	"RUNNING":  RUNNING,


### PR DESCRIPTION
In lxd, we're serializing states to json (and unserializing it), so it would be handy to not have to
re-define this in that code too.
