### PR TITLE
LICENSE: Add exception for static linkage

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,23 @@
+This software is licensed under the LGPLv2.1, included below.
+
+As a special exception to the GNU Lesser General Public License version 2.1
+("LGPL2.1"), the copyright holders of this Library give you permission to
+convey to a third party a Combined Work that links statically or dynamically
+to this Library without providing any Minimal Corresponding Source or
+Minimal Application Code or providing the installation information,
+provided that you comply with the other provisions of LGPL2.1
+and provided that you meet, for the Application the terms and conditions
+of the license(s) which apply to the Application.
+
+Except as stated in this special exception, the provisions of LGPL2.1 will
+continue to comply in full to this Library. If you modify this Library, you
+may apply this exception to your version of this Library, but you are not
+obliged to do so. If you do not wish to do so, delete this exception
+statement from your version. This exception does not (and cannot) modify any
+license terms which apply to the Application, with which you must still
+comply.
+
+
                   GNU LESSER GENERAL PUBLIC LICENSE
                        Version 2.1, February 1999
 


### PR DESCRIPTION
This adds an exception to the LGPLv2.1 for use of go-lxc in projects
that static link against it (such as most Go projects).

This change is done after getting approval of all existing copyright holders:
- David Cramer
- Fatih Arslan
- Kelsey Hightower
- S.Çağlar Onur
- Tycho Andersen

Signed-off-by: Stéphane Graber stgraber@ubuntu.com
