### PR TITLE
do not fail container start if not defined

### DIFF
--- a/container.go
+++ b/container.go
@@ -433,7 +433,7 @@ func (c *Container) Create(options TemplateOptions) error {
 
 // Start starts the container.
 func (c *Container) Start() error {
-	if err := c.makeSure(isDefined | isNotRunning); err != nil {
+	if err := c.makeSure(isNotRunning); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Starting an 'anonymous' container is perfectly valid (see lxc_start.c itself).
In particular, in lxd we will not have a container config file, rather we will
build up the config using SetConfigItem() using items from the database, and
start from that.  That is akin to 'lxc-start -s key=value -s key=value -n
name'.

Signed-off-by: Serge Hallyn serge.hallyn@ubuntu.com
