### PR TITLE
Add functions for retrieving IP address from interface by family

### DIFF
--- a/container.go
+++ b/container.go
@@ -1254,6 +1254,50 @@ func (c *Container) IPAddress(interfaceName string) ([]string, error) {
 	return convertArgs(result), nil
 }
 
+// IPv4Address returns the IPv4 address of the given network interface.
+func (c *Container) IPv4Address(interfaceName string) ([]string, error) {
+	if err := c.makeSure(isRunning); err != nil {
+		return nil, err
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	cinterface := C.CString(interfaceName)
+	defer C.free(unsafe.Pointer(cinterface))
+
+	cfamily := C.CString("inet")
+	defer C.free(unsafe.Pointer(cfamily))
+
+	result := C.go_lxc_get_ips(c.container, cinterface, cfamily, 0)
+	if result == nil {
+		return nil, ErrIPv4Addresses
+	}
+	return convertArgs(result), nil
+}
+
+// IPv6Address returns the IPv6 address of the given network interface.
+func (c *Container) IPv6Address(interfaceName string) ([]string, error) {
+	if err := c.makeSure(isRunning); err != nil {
+		return nil, err
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	cinterface := C.CString(interfaceName)
+	defer C.free(unsafe.Pointer(cinterface))
+
+	cfamily := C.CString("inet6")
+	defer C.free(unsafe.Pointer(cfamily))
+
+	result := C.go_lxc_get_ips(c.container, cinterface, cfamily, 0)
+	if result == nil {
+		return nil, ErrIPv6Addresses
+	}
+	return convertArgs(result), nil
+}
+
 // WaitIPAddresses waits until IPAddresses call returns something or time outs
 func (c *Container) WaitIPAddresses(timeout time.Duration) ([]string, error) {
 	now := time.Now()

--- a/lxc_test.go
+++ b/lxc_test.go
@@ -1051,6 +1051,36 @@ func TestIPAddress(t *testing.T) {
 	}
 }
 
+func TestIPv4Address(t *testing.T) {
+	c, err := NewContainer(ContainerName)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if unprivileged() {
+		time.Sleep(3 * time.Second)
+	}
+
+	if _, err := c.IPv4Address("lo"); err != nil {
+		t.Errorf(err.Error())
+	}
+}
+
+func TestIPv46ddress(t *testing.T) {
+	c, err := NewContainer(ContainerName)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if unprivileged() {
+		time.Sleep(3 * time.Second)
+	}
+
+	if _, err := c.IPv6Address("lo"); err != nil {
+		t.Errorf(err.Error())
+	}
+}
+
 func TestAddDeviceNode(t *testing.T) {
 	if unprivileged() {
 		t.Skip("skipping test in unprivileged mode.")


### PR DESCRIPTION
Adds `IPv4Address` and `IPv6Address` functions to containers.
