### PR TITLE
fix version checking

### DIFF
--- a/container.go
+++ b/container.go
@@ -72,11 +72,11 @@ func (c *Container) makeSure(flags int) error {
 		return ErrMethodNotAllowed
 	}
 
-	if flags&isGreaterEqualThanLXC11 != 0 && !(C.LXC_VERSION_MAJOR >= 1 && C.LXC_VERSION_MINOR >= 1) {
+	if flags&isGreaterEqualThanLXC11 != 0 && !VersionAtLeast(1, 1, 0) {
 		return ErrNotSupported
 	}
 
-	if flags&isGreaterEqualThanLXC20 != 0 && !(C.LXC_VERSION_MINOR >= 2 && C.LXC_VERSION_MAJOR >= 0) {
+	if flags&isGreaterEqualThanLXC20 != 0 && !VersionAtLeast(2, 0, 0) {
 		return ErrNotSupported
 	}
 

--- a/lxc-binding.go
+++ b/lxc-binding.go
@@ -196,3 +196,22 @@ func VersionNumber() (major int, minor int) {
 
 	return
 }
+
+func VersionAtLeast(major int, minor int, micro int) bool {
+	if major > C.LXC_VERSION_MAJOR {
+		return false
+	}
+
+	if major == C.LXC_VERSION_MAJOR &&
+		minor > C.LXC_VERSION_MINOR {
+		return false
+	}
+
+	if major == C.LXC_VERSION_MAJOR &&
+		minor == C.LXC_VERSION_MINOR &&
+		micro > C.LXC_VERSION_MICRO {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
Version 2.0 doesn't satisfy,

(C.LXC_VERSION_MAJOR >= 1 && C.LXC_VERSION_MINOR >= 1)

This fixes that (and the same error for 2.0), and adds a version checking
function so that users also don't have to fuck around with this logic like
I did just now :)

Signed-off-by: Tycho Andersen tycho.andersen@canonical.com
