### PR TITLE
Fixes #58

### DIFF
--- a/container.go
+++ b/container.go
@@ -454,10 +454,6 @@ func (c *Container) Start() error {
 
 // Execute executes the given command in a temporary container.
 func (c *Container) Execute(args ...string) ([]byte, error) {
-	if err := c.makeSure(isNotDefined); err != nil {
-		return nil, err
-	}
-
 	cargs := []string{"lxc-execute", "-n", c.Name(), "-P", c.ConfigPath(), "--"}
 	cargs = append(cargs, args...)
 


### PR DESCRIPTION
Execute method fails due to this check, no matter how you invoke it
Remove the previous definition check, as the container _must_ be defined
in order to execute commands in it. #58 
