### PR TITLE
Silence go get warning

### DIFF
--- a/lxc-binding.c
+++ b/lxc-binding.c
@@ -13,6 +13,8 @@
 #include <lxc/attach_options.h>
 #include <lxc/version.h>
 
+#include "lxc-binding.h"
+
 #define VERSION_AT_LEAST(major, minor, micro)							\
 	(!(major > LXC_VERSION_MAJOR ||								\
 	major == LXC_VERSION_MAJOR && minor > LXC_VERSION_MINOR ||				\


### PR DESCRIPTION
$> go get gopkg.in/lxc/go-lxc.v2
/opt/go/src/gopkg.in/lxc/go-lxc.v2/lxc-binding.c:366:70: warning: ‘struct migrate_opts’ declared inside parameter list
 int go_lxc_migrate(struct lxc_container *c, unsigned int cmd, struct migrate_opts *opts) {
                                                                      ^
/opt/go/src/gopkg.in/lxc/go-lxc.v2/lxc-binding.c:366:70: warning: its scope is only this definition or declaration, which is probably not what you want
