### PR TITLE
add support for liblxc's new action_script member in migrate_opts

### DIFF
--- a/container.go
+++ b/container.go
@@ -1502,10 +1502,9 @@ func (c *Container) Migrate(cmd uint, opts MigrateOptions) error {
 	defer C.free(unsafe.Pointer(cdirectory))
 
 	var cpredumpdir *C.char
-	cpredumpdir = nil
 
 	if opts.PredumpDir != "" {
-		cpredumpdir := C.CString(opts.PredumpDir)
+		cpredumpdir = C.CString(opts.PredumpDir)
 		defer C.free(unsafe.Pointer(cpredumpdir))
 	}
 

--- a/container.go
+++ b/container.go
@@ -1518,8 +1518,15 @@ func (c *Container) Migrate(cmd uint, opts MigrateOptions) error {
 		predump_dir: cpredumpdir,
 	}
 
+	var cActionScript *C.char
+	if opts.ActionScript != "" {
+		cActionScript = C.CString(opts.ActionScript)
+		defer C.free(unsafe.Pointer(cActionScript))
+	}
+
 	extras := C.struct_extra_migrate_opts{
 		preserves_inodes: C.bool(opts.PreservesInodes),
+		action_script:    cActionScript,
 	}
 
 	ret := C.int(C.go_lxc_migrate(c.container, C.uint(cmd), &copts, &extras))

--- a/lxc-binding.c
+++ b/lxc-binding.c
@@ -366,6 +366,10 @@ bool go_lxc_restore(struct lxc_container *c, char *directory, bool verbose) {
 }
 
 int go_lxc_migrate(struct lxc_container *c, unsigned int cmd, struct migrate_opts *opts, struct extra_migrate_opts *extras) {
+#if VERSION_AT_LEAST(2, 0, 4)
+	opts->action_script = extras->action_script;
+#endif
+
 #if VERSION_AT_LEAST(2, 0, 1)
 	opts->preserves_inodes = extras->preserves_inodes;
 #endif

--- a/lxc-binding.h
+++ b/lxc-binding.h
@@ -87,6 +87,7 @@ struct migrate_opts {
  */
 struct extra_migrate_opts {
 	bool preserves_inodes;
+	char *action_script;
 };
 int go_lxc_migrate(struct lxc_container *c, unsigned int cmd, struct migrate_opts *opts, struct extra_migrate_opts *extras);
 

--- a/options.go
+++ b/options.go
@@ -194,4 +194,5 @@ type MigrateOptions struct {
 	Stop            bool
 	PredumpDir      string
 	PreservesInodes bool
+	ActionScript    string
 }


### PR DESCRIPTION
```
17:18:02 stgraber | yeah, no problem pulling that in 2.0.4
```
