### PR TITLE
Fixed restore from checkpoint (was always failing)

### DIFF
--- a/container.go
+++ b/container.go
@@ -1478,7 +1478,7 @@ func (c *Container) Checkpoint(opts CheckpointOptions) error {
 
 // Restore restores the container from a checkpoint.
 func (c *Container) Restore(opts RestoreOptions) error {
-	if err := c.makeSure(isDefined | isGreaterEqualThanLXC11); err != nil {
+	if err := c.makeSure(isGreaterEqualThanLXC11); err != nil {
 		return err
 	}
 

--- a/container.go
+++ b/container.go
@@ -1478,7 +1478,7 @@ func (c *Container) Checkpoint(opts CheckpointOptions) error {
 
 // Restore restores the container from a checkpoint.
 func (c *Container) Restore(opts RestoreOptions) error {
-	if err := c.makeSure(isNotDefined | isGreaterEqualThanLXC11); err != nil {
+	if err := c.makeSure(isDefined | isGreaterEqualThanLXC11); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
``` c
if (!c->is_defined(c)) {
    fprintf(stderr, "%s is not defined\n", my_args.name);
    lxc_container_put(c);
    exit(1);
}
```

Based on this code from the lxc-checkpoint command, I think the container should be defined in order to process a restore from a checkpoint.
