### PR TITLE
Check for LXC_DEVEL

### DIFF
--- a/lxc-binding.c
+++ b/lxc-binding.c
@@ -15,10 +15,14 @@
 
 #include "lxc-binding.h"
 
+#ifndef LXC_DEVEL
+#define LXC_DEVEL 0
+#endif
+
 #define VERSION_AT_LEAST(major, minor, micro)							\
-	(!(major > LXC_VERSION_MAJOR ||								\
+	((LXC_DEVEL == 1) || (!(major > LXC_VERSION_MAJOR ||					\
 	major == LXC_VERSION_MAJOR && minor > LXC_VERSION_MINOR ||				\
-	major == LXC_VERSION_MAJOR && minor == LXC_VERSION_MINOR && micro > LXC_VERSION_MICRO))
+	major == LXC_VERSION_MAJOR && minor == LXC_VERSION_MINOR && micro > LXC_VERSION_MICRO)))
 
 bool go_lxc_defined(struct lxc_container *c) {
 	return c->is_defined(c);

--- a/lxc-binding.go
+++ b/lxc-binding.go
@@ -8,6 +8,9 @@ package lxc
 
 // #cgo pkg-config: lxc
 // #cgo LDFLAGS: -llxc -lutil
+// #ifndef LXC_DEVEL
+// #define LXC_DEVEL 0
+// #endif
 // #include <lxc/lxccontainer.h>
 // #include <lxc/version.h>
 // #include "lxc-binding.h"
@@ -198,6 +201,10 @@ func VersionNumber() (major int, minor int) {
 }
 
 func VersionAtLeast(major int, minor int, micro int) bool {
+	if C.LXC_DEVEL == 1 {
+		return true
+	}
+
 	if major > C.LXC_VERSION_MAJOR {
 		return false
 	}


### PR DESCRIPTION
When we detect that `LXC_DEVEL` is set in the `LXC` header `version.h` we return `true` since we can assume that all features `LXD` could possibly need are present.
