### PR TITLE
[RFC] add c->attach() wrapper returning PID of attached process

### DIFF
--- a/lxc-binding.h
+++ b/lxc-binding.h
@@ -60,6 +60,17 @@ extern int go_lxc_attach(struct lxc_container *c,
 		char *initial_cwd,
 		char **extra_env_vars,
 		char **extra_keep_env);
+extern int go_lxc_attach_no_wait(struct lxc_container *c,
+		bool clear_env,
+		int namespaces,
+		long personality,
+		uid_t uid, gid_t gid,
+		int stdinfd, int stdoutfd, int stderrfd,
+		char *initial_cwd,
+		char **extra_env_vars,
+		char **extra_keep_env,
+		const char * const argv[],
+		pid_t *attached_pid);
 extern int go_lxc_console_getfd(struct lxc_container *c, int ttynum);
 extern int go_lxc_snapshot_list(struct lxc_container *c, struct lxc_snapshot **ret);
 extern int go_lxc_snapshot(struct lxc_container *c);

--- a/lxc_test.go
+++ b/lxc_test.go
@@ -926,6 +926,77 @@ func TestCPUStats(t *testing.T) {
 	}
 }
 
+func TestRunCommandNoWait(t *testing.T) {
+	c, err := NewContainer("TestRunCommandNoWait")
+	if err != nil {
+		t.Errorf(err.Error())
+		t.FailNow()
+	}
+
+	options := DownloadTemplateOptions
+	if !unprivileged() {
+		options = BusyboxTemplateOptions
+	}
+
+	if err := c.Create(options); err != nil {
+		t.Errorf(err.Error())
+		t.FailNow()
+	}
+	defer c.Destroy()
+
+	err = c.Start()
+	if err != nil {
+		t.Errorf(err.Error())
+		t.FailNow()
+	}
+	defer c.Stop()
+
+	argsThree := []string{"/bin/sh", "-c", "exit 0"}
+	pid, err := c.RunCommandNoWait(argsThree, DefaultAttachOptions)
+	if err != nil {
+		t.Errorf(err.Error())
+		t.FailNow()
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		t.Errorf(err.Error())
+		t.FailNow()
+	}
+
+	procState, err := proc.Wait()
+	if err != nil {
+		t.Errorf(err.Error())
+		t.FailNow()
+	}
+	if !procState.Success() {
+		t.Errorf("Expected success")
+		t.FailNow()
+	}
+
+	argsThree = []string{"/bin/sh", "-c", "exit 0"}
+	pid, err = c.RunCommandNoWait(argsThree, DefaultAttachOptions)
+	if err != nil {
+		t.Errorf(err.Error())
+		t.FailNow()
+	}
+	proc, err = os.FindProcess(pid)
+	if err != nil {
+		t.Errorf(err.Error())
+		t.FailNow()
+	}
+
+	procState, err = proc.Wait()
+	if err != nil {
+		t.Errorf(err.Error())
+		t.FailNow()
+	}
+	if procState.Success() {
+		t.Errorf("Expected failure")
+		t.FailNow()
+	}
+}
+
 func TestRunCommand(t *testing.T) {
 	c, err := NewContainer(ContainerName)
 	if err != nil {


### PR DESCRIPTION
Add a wrapper to call low-level `c->attach()` which stores the `PID` of the attached process in one of its arguments. In contrast to all the other wrappers `go_lxc_attach_no_wait()` will not wait on the attached process. This will allow more flexibility in `LXD` when executing commands in a container.

The name of the wrappers `go_lxc_attach_no_wait()` and `RunCommandNoWait()` are not ideal but `go_lxc_attach()` and `RunCommand()` are already taken by wrappers that wait on the executing command. Suggestions for better names very welcome. :)
