### PR TITLE
Move LXC_DEVEL define to after version.h include

### DIFF
--- a/lxc-binding.go
+++ b/lxc-binding.go
@@ -8,12 +8,12 @@ package lxc
 
 // #cgo pkg-config: lxc
 // #cgo LDFLAGS: -llxc -lutil
-// #ifndef LXC_DEVEL
-// #define LXC_DEVEL 0
-// #endif
 // #include <lxc/lxccontainer.h>
 // #include <lxc/version.h>
 // #include "lxc-binding.h"
+// #ifndef LXC_DEVEL
+// #define LXC_DEVEL 0
+// #endif
 import "C"
 
 import (


### PR DESCRIPTION
Otherwise it'll always define it and lead to it being defined twice.

Signed-off-by: Stéphane Graber stgraber@ubuntu.com
