### PR TITLE
bindings: adapt to new liblxc version output

### DIFF
--- a/lxc-binding.go
+++ b/lxc-binding.go
@@ -64,9 +64,14 @@ func Release(c *Container) bool {
 // Version returns the LXC version.
 func Version() string {
 	version := C.GoString(C.lxc_get_version())
-	if C.LXC_DEVEL == 1 {
+
+	// New liblxc versions append "-devel" when LXC_DEVEL is set.
+	if strings.HasSuffix(version, "-devel") {
+		return fmt.Sprintf("%s (devel)", version[:(len(version) - len("-devel"))])
+	} else if C.LXC_DEVEL == 1 {
 		version = fmt.Sprintf("%s (devel)", version)
 	}
+
 	return version
 }
 


### PR DESCRIPTION
liblxc will now append "-devel" (e.g. 2.1.0-devel") when LXC_DEVEL is true.
From a semantic versioning perspective liblxc is doing a saner thing than go-lxc
with appending "-devel" instead of " (devel)" but we shouldn't break existing
user. They might already rely on " (devel)" so let's keep it.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>