### PR TITLE
Fix the locking logic (v2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ escape-analysis:
 ctags:
 	@ctags -R --languages=c,go
 
+scope:
+	@echo "$(OK_COLOR)==> Exported container calls in container.go $(NO_COLOR)"
+	@/bin/grep -E "\bc+\.([A-Z])\w+" container.go || true
+
 setup-test-cgroup:
 	for d in /sys/fs/cgroup/*; do \
 	    [ -f $$d/cgroup.clone_children ] && echo 1 | sudo tee $$d/cgroup.clone_children; \

--- a/lxc_test.go
+++ b/lxc_test.go
@@ -690,6 +690,17 @@ func TestInterfaces(t *testing.T) {
 	}
 }
 
+func TestInterfaceStats(t *testing.T) {
+	c, err := NewContainer(ContainerName)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if _, err := c.InterfaceStats(); err != nil {
+		t.Errorf(err.Error())
+	}
+}
+
 func TestMemoryUsage(t *testing.T) {
 	c, err := NewContainer(ContainerName)
 	if err != nil {


### PR DESCRIPTION
The original code where we were doing following
```
func X()  {
    call makesure
	makesure locks
	...work
	makesure unlocks
    lock
    ...work
    unlock
}
```
was potentially racy as someone else could obtain the lock in between
makesure and mutex.Lock call.

Changes since last attempt:

- Running LXD tests locally ends up with success.
```
...
==> Deleting all storage pools
Storage pool lxdtest-cjU deleted
==> Checking for locked DB tables
==> Checking for leftover files
==> Checking for leftover DB entries
==> Tearing down directory backend in
/home/caglar/go/src/github.com/lxc/lxd/test/tmp.IQA/cjU

==> Test result: success
...
```