### PR TITLE
migrate: add new CRIU feature check support

### DIFF
--- a/container.go
+++ b/container.go
@@ -1779,9 +1779,10 @@ func (c *Container) Migrate(cmd uint, opts MigrateOptions) error {
 	}
 
 	extras := C.struct_extra_migrate_opts{
-		preserves_inodes: C.bool(opts.PreservesInodes),
-		action_script:    cActionScript,
-		ghost_limit:      C.uint64_t(opts.GhostLimit),
+		preserves_inodes:  C.bool(opts.PreservesInodes),
+		action_script:     cActionScript,
+		ghost_limit:       C.uint64_t(opts.GhostLimit),
+		features_to_check: C.uint64_t(opts.FeaturesToCheck),
 	}
 
 	ret := C.int(C.go_lxc_migrate(c.container, C.uint(cmd), &copts, &extras))

--- a/lxc-binding.c
+++ b/lxc-binding.c
@@ -410,6 +410,9 @@ bool go_lxc_restore(struct lxc_container *c, char *directory, bool verbose) {
 }
 
 int go_lxc_migrate(struct lxc_container *c, unsigned int cmd, struct migrate_opts *opts, struct extra_migrate_opts *extras) {
+#if VERSION_AT_LEAST(3, 0, 0)
+	opts->features_to_check = extras->features_to_check;
+#endif
 #if VERSION_AT_LEAST(2, 0, 4)
 	opts->action_script = extras->action_script;
 	opts->ghost_limit = extras->ghost_limit;

--- a/lxc-binding.h
+++ b/lxc-binding.h
@@ -108,6 +108,7 @@ struct extra_migrate_opts {
 	bool preserves_inodes;
 	char *action_script;
 	uint64_t ghost_limit;
+	uint64_t features_to_check;
 };
 int go_lxc_migrate(struct lxc_container *c, unsigned int cmd, struct migrate_opts *opts, struct extra_migrate_opts *extras);
 

--- a/options.go
+++ b/options.go
@@ -197,6 +197,7 @@ type MigrateOptions struct {
 	Stop            bool
 	PreservesInodes bool
 	GhostLimit      uint64
+	FeaturesToCheck CriuFeatures
 }
 
 // ConsoleLogOptioins type is used for defining console log options.

--- a/type.go
+++ b/type.go
@@ -260,7 +260,15 @@ const (
 )
 
 const (
-	MIGRATE_PRE_DUMP = 0
-	MIGRATE_DUMP     = 1
-	MIGRATE_RESTORE  = 2
+	MIGRATE_PRE_DUMP       = 0
+	MIGRATE_DUMP           = 1
+	MIGRATE_RESTORE        = 2
+	MIGRATE_FEATURE_CHECK  = 3
+)
+
+type CriuFeatures uint64
+
+const (
+	FEATURE_MEM_TRACK  CriuFeatures = 1 << iota
+	FEATURE_LAZY_PAGES
 )


### PR DESCRIPTION
This adds support to use the newly added MIGRATE_FEATURE_CHECK command
in the migrate() call. With this change LXD can query LXC if CRIU
supports features like dirty memory tracking or userfaultfd based
process migration.

Signed-off-by: Adrian Reber <areber@redhat.com>