### PR TITLE
add ErrorNum to return the last error from the container

### DIFF
--- a/container.go
+++ b/container.go
@@ -1892,3 +1892,9 @@ func (c *Container) ConsoleLog(opt ConsoleLogOptions) ([]byte, error) {
 
 	return C.GoBytes(unsafe.Pointer(cl.data), numBytes), nil
 }
+
+// ErrorNum returns the error_num field of the container.
+func (c *Container) ErrorNum() int {
+	cError := C.go_lxc_error_num(c.container)
+	return int(cError)
+}

--- a/lxc-binding.c
+++ b/lxc-binding.c
@@ -454,6 +454,11 @@ bool go_lxc_config_item_is_supported(const char *key)
 #endif
 }
 
+int go_lxc_error_num(struct lxc_container *c)
+{
+	return c->error_num;
+}
+
 int go_lxc_console_log(struct lxc_container *c, struct lxc_console_log *log) {
 #if VERSION_AT_LEAST(3, 0, 0)
 	return c->console_log(c, log);

--- a/lxc-binding.h
+++ b/lxc-binding.h
@@ -124,3 +124,4 @@ struct lxc_console_log {
 #endif
 
 extern int go_lxc_console_log(struct lxc_container *c, struct lxc_console_log *log);
+extern int go_lxc_error_num(struct lxc_container *c);


### PR DESCRIPTION
As it stands right now, there is no way to figure out what the exit code of
a container spawned by StartExecute() was. liblxc stores the value in
c->error_num, so let's make that accessible.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>