### PR TITLE
fix incorrect status code from runCommandStatus

### DIFF
--- a/container.go
+++ b/container.go
@@ -1282,7 +1282,12 @@ func (c *Container) runCommandStatus(args []string, options AttachOptions) (int,
 		cargs,
 	))
 
-	return ret, nil
+	if ret < 0 {
+		return ret, nil
+	}
+
+	// Mirror the behavior of WEXITSTATUS().
+	return int((ret & 0xFF00) >> 8), nil
 }
 
 // RunCommandStatus attachs a shell and runs the command within the container.


### PR DESCRIPTION
runCommandStatus should return correct status codes (use of WEXITSTATUS macro)
as lxc-execute does in https://github.com/lxc/lxc/blob/master/src/lxc/tools/lxc_execute.c#L239