### PR TITLE
[RFC] Stop using finalizers

### DIFF
--- a/container.go
+++ b/container.go
@@ -101,6 +101,18 @@ func (c *Container) setCgroupItemWithByteSize(filename string, limit ByteSize, m
 	return nil
 }
 
+// Release decrements the reference counter of the container object.
+// nil on success or if reference was successfully dropped and container has been freed, and ErrReleaseFailed on error.
+func (c *Container) Release() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if C.lxc_container_put(c.container) == -1 {
+		return ErrReleaseFailed
+	}
+	return nil
+}
+
 func (c *Container) name() string {
 	return C.GoString(c.container.name)
 }

--- a/error.go
+++ b/error.go
@@ -67,6 +67,7 @@ var (
 	ErrTemplateNotAllowed            = NewError("unprivileged users only allowed to use \"download\" template")
 	ErrUnfreezeFailed                = NewError("unfreezing the container failed")
 	ErrUnknownBackendStore           = NewError("unknown backend type")
+	ErrReleaseFailed                 = NewError("releasing the container failed")
 )
 
 // Error represents a basic error that implies the error interface.

--- a/examples/attach/attach.go
+++ b/examples/attach/attach.go
@@ -35,6 +35,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	options := lxc.DefaultAttachOptions
 	options.ClearEnv = false

--- a/examples/attach_with_pipes/attach_with_pipes.go
+++ b/examples/attach_with_pipes/attach_with_pipes.go
@@ -39,6 +39,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	stdoutReader, stdoutWriter, err := os.Pipe()
 	if err != nil {

--- a/examples/checkpoint/checkpoint.go
+++ b/examples/checkpoint/checkpoint.go
@@ -35,6 +35,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	if verbose {
 		c.SetVerbosity(lxc.Verbose)

--- a/examples/clone/clone.go
+++ b/examples/clone/clone.go
@@ -31,6 +31,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	if backend == 0 {
 		log.Fatalf("ERROR: %s\n", lxc.ErrUnknownBackendStore)

--- a/examples/concurrent_create/concurrent_create.go
+++ b/examples/concurrent_create/concurrent_create.go
@@ -39,6 +39,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("ERROR: %s\n", err.Error())
 			}
+			defer c.Release()
 
 			log.Printf("Creating the container (%d)...\n", i)
 			if err := c.Create(options); err != nil {

--- a/examples/concurrent_destroy/concurrent_destroy.go
+++ b/examples/concurrent_destroy/concurrent_destroy.go
@@ -38,6 +38,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("ERROR: %s\n", err.Error())
 			}
+			defer c.Release()
 
 			log.Printf("Destroying the container (%d)...\n", i)
 			if err := c.Destroy(); err != nil {

--- a/examples/concurrent_shutdown/concurrent_shutdown.go
+++ b/examples/concurrent_shutdown/concurrent_shutdown.go
@@ -39,6 +39,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("ERROR: %s\n", err.Error())
 			}
+			defer c.Release()
 
 			log.Printf("Shutting down the container (%d)...\n", i)
 			if err := c.Shutdown(30 * time.Second); err != nil {

--- a/examples/concurrent_start/concurrent_start.go
+++ b/examples/concurrent_start/concurrent_start.go
@@ -38,6 +38,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("ERROR: %s\n", err.Error())
 			}
+			defer c.Release()
 
 			log.Printf("Starting the container (%d)...\n", i)
 			if err := c.Start(); err != nil {

--- a/examples/concurrent_stop/concurrent_stop.go
+++ b/examples/concurrent_stop/concurrent_stop.go
@@ -38,6 +38,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("ERROR: %s\n", err.Error())
 			}
+			defer c.Release()
 
 			log.Printf("Stoping the container (%d)...\n", i)
 			if err := c.Stop(); err != nil {

--- a/examples/concurrent_stress/concurrent_stress.go
+++ b/examples/concurrent_stress/concurrent_stress.go
@@ -62,6 +62,7 @@ func main() {
 					if err != nil {
 						log.Fatalf("ERROR: %s\n", err.Error())
 					}
+					defer c.Release()
 
 					if mode == "CREATE" && startstop == false {
 						log.Printf("\t\tCreating the container (%d)...\n", i)

--- a/examples/config/config.go
+++ b/examples/config/config.go
@@ -27,11 +27,11 @@ func init() {
 }
 
 func main() {
-
 	c, err := lxc.NewContainer(name, lxcpath)
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	//setting hostname
 	err = c.SetConfigItem("lxc.utsname", hostname)

--- a/examples/console/console.go
+++ b/examples/console/console.go
@@ -29,6 +29,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	log.Printf("Attaching to container's console...\n")
 	if err := c.Console(lxc.DefaultConsoleOptions); err != nil {

--- a/examples/create/create.go
+++ b/examples/create/create.go
@@ -43,6 +43,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	log.Printf("Creating container...\n")
 	if verbose {

--- a/examples/create_snapshot/create_snapshot.go
+++ b/examples/create_snapshot/create_snapshot.go
@@ -29,6 +29,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	log.Printf("Snapshoting the container...\n")
 	if _, err := c.CreateSnapshot(); err != nil {

--- a/examples/destroy/destroy.go
+++ b/examples/destroy/destroy.go
@@ -29,6 +29,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	log.Printf("Destroying container...\n")
 	if err := c.Destroy(); err != nil {

--- a/examples/destroy_snapshots/destroy_snapshots.go
+++ b/examples/destroy_snapshots/destroy_snapshots.go
@@ -27,5 +27,6 @@ func main() {
 				log.Fatalf("ERROR: %s\n", err.Error())
 			}
 		}
+		c[i].Release()
 	}
 }

--- a/examples/device_add_remove/device_add_remove.go
+++ b/examples/device_add_remove/device_add_remove.go
@@ -30,6 +30,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	if err := c.AddDeviceNode("/dev/network_latency"); err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())

--- a/examples/execute/execute.go
+++ b/examples/execute/execute.go
@@ -29,6 +29,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	c.LoadConfigFile(lxc.DefaultConfigPath())
 	if output, err := c.Execute("uname", "-a"); err != nil {

--- a/examples/freeze/freeze.go
+++ b/examples/freeze/freeze.go
@@ -30,6 +30,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	log.Printf("Freezing the container...\n")
 	if err := c.Freeze(); err != nil {

--- a/examples/interfaces/interfaces.go
+++ b/examples/interfaces/interfaces.go
@@ -29,6 +29,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	log.Printf("Interfaces\n")
 	if interfaces, err := c.Interfaces(); err != nil {

--- a/examples/ipaddress/ipaddress.go
+++ b/examples/ipaddress/ipaddress.go
@@ -29,6 +29,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	log.Printf("IPAddress(\"lo\")\n")
 	if addresses, err := c.IPAddress("lo"); err != nil {

--- a/examples/limit/limit.go
+++ b/examples/limit/limit.go
@@ -29,6 +29,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	memLimit, err := c.MemoryLimit()
 	if err != nil {

--- a/examples/list/list.go
+++ b/examples/list/list.go
@@ -27,6 +27,7 @@ func main() {
 	c := lxc.DefinedContainers(lxcpath)
 	for i := range c {
 		log.Printf("%s (%s)\n", c[i].Name(), c[i].State())
+		c[i].Release()
 	}
 
 	log.Println()
@@ -35,6 +36,7 @@ func main() {
 	c = lxc.ActiveContainers(lxcpath)
 	for i := range c {
 		log.Printf("%s (%s)\n", c[i].Name(), c[i].State())
+		c[i].Release()
 	}
 
 	log.Println()
@@ -43,5 +45,6 @@ func main() {
 	c = lxc.ActiveContainers(lxcpath)
 	for i := range c {
 		log.Printf("%s (%s)\n", c[i].Name(), c[i].State())
+		c[i].Release()
 	}
 }

--- a/examples/list_keys/list_keys.go
+++ b/examples/list_keys/list_keys.go
@@ -29,6 +29,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	for _, k := range c.ConfigKeys() {
 		log.Printf("%s -> %s", k, c.ConfigItem(k))

--- a/examples/list_snapshots/list_snapshots.go
+++ b/examples/list_snapshots/list_snapshots.go
@@ -28,5 +28,6 @@ func main() {
 			log.Printf("LXC path: %s\n", s.Path)
 			log.Println()
 		}
+		c[i].Release()
 	}
 }

--- a/examples/reboot/reboot.go
+++ b/examples/reboot/reboot.go
@@ -29,6 +29,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	log.Printf("Rebooting the container...\n")
 	if err := c.Reboot(); err != nil {

--- a/examples/rename/rename.go
+++ b/examples/rename/rename.go
@@ -31,6 +31,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	log.Printf("Renaming container to %s...\n", newname)
 	if err := c.Rename(newname); err != nil {

--- a/examples/restore_snapshot/restore_snapshot.go
+++ b/examples/restore_snapshot/restore_snapshot.go
@@ -29,6 +29,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	log.Printf("Restoring the container...\n")
 	snapshot := lxc.Snapshot{Name: "snap0"}

--- a/examples/shutdown/shutdown.go
+++ b/examples/shutdown/shutdown.go
@@ -30,6 +30,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	log.Printf("Shutting down the container...\n")
 	if err := c.Shutdown(30 * time.Second); err != nil {

--- a/examples/start/start.go
+++ b/examples/start/start.go
@@ -30,6 +30,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	c.SetLogFile("/tmp/" + name + ".log")
 	c.SetLogLevel(lxc.TRACE)

--- a/examples/stats/stats.go
+++ b/examples/stats/stats.go
@@ -29,6 +29,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	// mem
 	memUsed, err := c.MemoryUsage()

--- a/examples/stop/stop.go
+++ b/examples/stop/stop.go
@@ -29,6 +29,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	c.SetLogFile("/tmp/" + name + ".log")
 	c.SetLogLevel(lxc.TRACE)

--- a/examples/unfreeze/unfreeze.go
+++ b/examples/unfreeze/unfreeze.go
@@ -30,6 +30,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR: %s\n", err.Error())
 	}
+	defer c.Release()
 
 	log.Printf("Unfreezing the container...\n")
 	if err := c.Unfreeze(); err != nil {

--- a/lxc-binding.go
+++ b/lxc-binding.go
@@ -18,13 +18,13 @@ import "C"
 
 import (
 	"fmt"
-	"runtime"
 	"strconv"
 	"strings"
 	"unsafe"
 )
 
 // NewContainer returns a new container struct.
+// Caller needs to call Release() on the returned container to release its resources.
 func NewContainer(name string, lxcpath ...string) (*Container, error) {
 	var container *C.struct_lxc_container
 
@@ -45,8 +45,6 @@ func NewContainer(name string, lxcpath ...string) (*Container, error) {
 	}
 	c := &Container{container: container, verbosity: Quiet}
 
-	// http://golang.org/pkg/runtime/#SetFinalizer
-	runtime.SetFinalizer(c, Release)
 	return c, nil
 }
 
@@ -57,13 +55,10 @@ func Acquire(c *Container) bool {
 
 // Release decrements the reference counter of the container object.
 func Release(c *Container) bool {
-	// http://golang.org/pkg/runtime/#SetFinalizer
-	runtime.SetFinalizer(c, nil)
-
-	// Go is bad at refcounting sometimes
-	c.mu.Lock()
-
-	return C.lxc_container_put(c.container) == 1
+	if C.lxc_container_put(c.container) == -1 {
+		return false
+	}
+	return true
 }
 
 // Version returns the LXC version.
@@ -124,6 +119,7 @@ func ContainerNames(lxcpath ...string) []string {
 
 // Containers returns the defined and active containers on the system. Only
 // containers that could retrieved successfully are returned.
+// Caller needs to call Release() on the returned containers to release resources.
 func Containers(lxcpath ...string) []*Container {
 	var containers []*Container
 
@@ -159,6 +155,7 @@ func DefinedContainerNames(lxcpath ...string) []string {
 
 // DefinedContainers returns the defined containers on the system.  Only
 // containers that could retrieved successfully are returned.
+// Caller needs to call Release() on the returned containers to release resources.
 func DefinedContainers(lxcpath ...string) []*Container {
 	var containers []*Container
 
@@ -194,6 +191,7 @@ func ActiveContainerNames(lxcpath ...string) []string {
 
 // ActiveContainers returns the active containers on the system. Only
 // containers that could retrieved successfully are returned.
+// Caller needs to call Release() on the returned containers to release resources.
 func ActiveContainers(lxcpath ...string) []*Container {
 	var containers []*Container
 


### PR DESCRIPTION
Handling our garbage explicitly is way more simpler and idiomatic then relying on runtime magic. Finalizers also are not guaranteed to run so stop using them, instead Container now provides Release() to call it via defer.

^ the idea is not to merge this as it is but start a discussion and learn whether you agree with this or not. I'll rebase/fix/cleanup after the discussion - this is for triggering the initial discussion.

P.S: this PR includes #114 for now