### PR TITLE
Support working without template

### DIFF
--- a/lxc-binding.c
+++ b/lxc-binding.c
@@ -5,6 +5,7 @@
 // +build linux,cgo
 
 #include <stdbool.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <errno.h>
@@ -52,6 +53,9 @@ bool go_lxc_want_close_all_fds(struct lxc_container *c, bool state) {
 }
 
 bool go_lxc_create(struct lxc_container *c, const char *t, const char *bdevtype, int flags, char * const argv[]) {
+	if (strncmp(t, "none", strlen(t)) == 0) {
+		return c->create(c,NULL,bdevtype, NULL, !!(flags & LXC_CREATE_QUIET), argv);
+	}
 	return c->create(c, t, bdevtype, NULL, !!(flags & LXC_CREATE_QUIET), argv);
 }
 

--- a/lxc-binding.c
+++ b/lxc-binding.c
@@ -54,7 +54,7 @@ bool go_lxc_want_close_all_fds(struct lxc_container *c, bool state) {
 
 bool go_lxc_create(struct lxc_container *c, const char *t, const char *bdevtype, int flags, char * const argv[]) {
 	if (strncmp(t, "none", strlen(t)) == 0) {
-		return c->create(c,NULL,bdevtype, NULL, !!(flags & LXC_CREATE_QUIET), argv);
+		return c->create(c, NULL, bdevtype, NULL, !!(flags & LXC_CREATE_QUIET), argv);
 	}
 	return c->create(c, t, bdevtype, NULL, !!(flags & LXC_CREATE_QUIET), argv);
 }


### PR DESCRIPTION
Adds the option to use the template "none" that creates a container without template as in _lxc-create_ command #120 