### PR TITLE
Added static build support using -tags static_build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,18 +11,22 @@ format:
 test-privileged:
 	@echo "$(OK_COLOR)==> Running tests for privileged user $(NO_COLOR)"
 	@sudo `which go` test -v -coverprofile=/tmp/priv.out
+	@sudo `which go` test -tags static_build -v -coverprofile=/tmp/priv.out
 
 test-privileged-race:
 	@echo "$(OK_COLOR)==> Running tests with -race flag for privileged user $(NO_COLOR)"
 	@sudo `which go` test -race -v
+	@sudo `which go` test -tags static_build -race -v
 
 test:
 	@echo "$(OK_COLOR)==> Running tests for unprivileged user $(NO_COLOR)"
 	@`which go` test -v -coverprofile=/tmp/unpriv.out
+	@`which go` test -tags static_build -v -coverprofile=/tmp/unpriv.out
 
 test-race:
 	@echo "$(OK_COLOR)==> Running tests with -race flag for unprivileged user $(NO_COLOR)"
 	@`which go` test -race -v
+	@`which go` test -tags static_build -race -v
 
 cover:
 	@echo "$(OK_COLOR)==> Running cover for privileged user $(NO_COLOR)"

--- a/linking_dynamic.go
+++ b/linking_dynamic.go
@@ -1,0 +1,10 @@
+// Copyright © 2013, 2014, The Go-LXC Authors. All rights reserved.
+// Use of this source code is governed by a LGPLv2.1
+// license that can be found in the LICENSE file.
+
+// +build linux,cgo,!static_build
+
+package lxc
+
+// #cgo LDFLAGS: -llxc -lutil
+import "C"

--- a/linking_static.go
+++ b/linking_static.go
@@ -1,0 +1,10 @@
+// Copyright © 2013, 2014, The Go-LXC Authors. All rights reserved.
+// Use of this source code is governed by a LGPLv2.1
+// license that can be found in the LICENSE file.
+
+// +build linux,cgo,static_build
+
+package lxc
+
+// #cgo LDFLAGS: -static -llxc -lseccomp -lutil -lcap
+import "C"

--- a/lxc-binding.go
+++ b/lxc-binding.go
@@ -7,7 +7,6 @@
 package lxc
 
 // #cgo pkg-config: lxc
-// #cgo LDFLAGS: -llxc -lutil
 // #include <lxc/lxccontainer.h>
 // #include <lxc/version.h>
 // #include "lxc-binding.h"


### PR DESCRIPTION
Some golang applications may require static builds of their binaries such as OCI runtimes(crio-lxc).
This PR adds support for this use-case by adding a static_build tag.