### PR TITLE
[dontmerge][rfc] Try to make static linking work (fails)

### DIFF
--- a/linking_static.go
+++ b/linking_static.go
@@ -6,5 +6,7 @@
 
 package lxc
 
-// #cgo LDFLAGS: -static -llxc -lseccomp -lutil -lcap
+// #cgo LDFLAGS: -static -llxc -lutil -lselinux -lcap -lseccomp
+// #cgo pkg-config: lxc libseccomp libselinux libcap gnutls
+// #include <selinux/selinux.h>
 import "C"

--- a/lxc-binding.go
+++ b/lxc-binding.go
@@ -6,7 +6,7 @@
 
 package lxc
 
-// #cgo pkg-config: lxc
+// #cgo pkg-config: lxc libseccomp libselinux libcap gnutls
 // #include <lxc/lxccontainer.h>
 // #include <lxc/version.h>
 // #include "lxc-binding.h"


### PR DESCRIPTION
Hi @caglar10ur 

I'm trying to get github.com/lxc/crio-lxc with PR 15 to build.  It's doing a static build and importing go-lxc.  When I add -x to the go build line, I see

```
TERM='dumb' gcc -I . -fPIC -m64 -pthread -fmessage-length=0 -fdebug-prefix-map=$WORK/b055=/tmp/go-build -gno-record-gcc-switches -o $WORK/b055/_cgo_.o $WORK/b055/_cgo_main.o $WORK/b055/_x001.o $WORK/b055/_x002.o $WORK/b055/_x003.o $WORK/b055/_x004.o $WORK/b055/_x005.o $WORK/b055/_x006.o $WORK/b055/_x007.o -g -O2 -static -llxc -lseccomp -lutil -lcap -llxc -lutil
```

but i've added libselinux to the pkg-config line here, as well as in crio-lxc's internal.go.  On the system where I'm building,

```
ubuntu@criolxc:~/crio-lxc$ pkg-config --libs libselinux
-lselinux
```

So why am I not seeing -lselinux in the gcc command being done by 'go build' above?