### PR TITLE
Switch to fetching linker flags from pkg-config

### DIFF
--- a/linking_dynamic.go
+++ b/linking_dynamic.go
@@ -6,5 +6,5 @@
 
 package lxc
 
-// #cgo LDFLAGS: -llxc -lutil
+// #cgo pkg-config: lxc
 import "C"

--- a/linking_static.go
+++ b/linking_static.go
@@ -6,5 +6,6 @@
 
 package lxc
 
-// #cgo LDFLAGS: -static -llxc -lseccomp -lutil -lcap
+// #cgo pkg-config: --static lxc
+// #cgo LDFLAGS: -static
 import "C"

--- a/lxc-binding.go
+++ b/lxc-binding.go
@@ -6,7 +6,6 @@
 
 package lxc
 
-// #cgo pkg-config: lxc
 // #include <lxc/lxccontainer.h>
 // #include <lxc/version.h>
 // #include "lxc-binding.h"


### PR DESCRIPTION
Fetching linker flags should be left to distribution maintainers or developers as they may have compiled liblxc with different flags. Switching pkg-config will help as it's pc files are trivially editable and are present on most distributions.