### PR TITLE
go-lxc: update cgo build flags

### DIFF
--- a/cgo_1.12.go
+++ b/cgo_1.12.go
@@ -2,10 +2,9 @@
 // Use of this source code is governed by a LGPLv2.1
 // license that can be found in the LICENSE file.
 
-// +build linux,cgo,!static_build
+// +build >go1.10,linux,cgo
 
 package lxc
 
-// #cgo CFLAGS: -std=gnu11 -Wvla -Werror
-// #cgo pkg-config: lxc
+// #cgo CFLAGS: -fvisibility=hidden
 import "C"

--- a/linking_static.go
+++ b/linking_static.go
@@ -6,6 +6,7 @@
 
 package lxc
 
+// #cgo CFLAGS: -std=gnu11 -Wvla -Werror
 // #cgo pkg-config: --static lxc
 // #cgo LDFLAGS: -static
 import "C"


### PR DESCRIPTION
Use the same flags we require in LXD. Especially, hide all C functions
to avoid symbol resolution clashes.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>