### PR TITLE
api: make InitPidFd() and SeccompNotifyFd() return os.File and error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ os:
   - linux
 
 go:
-  - "1.10"
-  - "1.11"
-  - "1.12"
+  - 1.10.x
+  - 1.11.x
+  - 1.12.x
+  - 1.13.x
+  - 1.14.x
   - tip
 
 matrix:
@@ -34,6 +36,7 @@ before_install:
 
 install:
   - go get golang.org/x/tools/cmd/goimports
+  - go get golang.org/x/sys/unix
   - go get gopkg.in/lxc/go-lxc.v2
 
 script:

--- a/container.go
+++ b/container.go
@@ -25,6 +25,8 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 // Container struct
@@ -297,13 +299,17 @@ func (c *Container) InitPid() int {
 	return int(C.go_lxc_init_pid(c.container))
 }
 
-// InitPidFd returns the pidfd of the container's init process as
-// seen from outside the container.
-func (c *Container) InitPidFd() int {
+// InitPidFd returns the pidfd of the container's init process.
+func (c *Container) InitPidFd() (*os.File, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return int(C.go_lxc_init_pidfd(c.container))
+	pidfd := int(C.go_lxc_init_pidfd(c.container))
+	if pidfd < 0 {
+		return nil, unix.Errno(unix.EBADF)
+	}
+
+	return os.NewFile(uintptr(pidfd), "[pidfd]"), nil
 }
 
 // SeccompNotifyFd returns the seccomp notify fd of the container.


### PR DESCRIPTION
Make it return os.File so callers can simply call defer f.Close().
Callers only wanting the fd can simply call f.Fd(), so no real downsides.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>