### PR TITLE
Support backing store options

### DIFF
--- a/lxc-binding.c
+++ b/lxc-binding.c
@@ -75,11 +75,11 @@ bool go_lxc_want_close_all_fds(struct lxc_container *c, bool state) {
 	return c->want_close_all_fds(c, state);
 }
 
-bool go_lxc_create(struct lxc_container *c, const char *t, const char *bdevtype, int flags, char * const argv[]) {
+bool go_lxc_create(struct lxc_container *c, const char *t, const char *bdevtype, struct bdev_specs *specs, int flags, char * const argv[]) {
 	if (strncmp(t, "none", strlen(t)) == 0) {
-		return c->create(c, NULL, bdevtype, NULL, !!(flags & LXC_CREATE_QUIET), argv);
+		return c->create(c, NULL, bdevtype, specs, !!(flags & LXC_CREATE_QUIET), argv);
 	}
-	return c->create(c, t, bdevtype, NULL, !!(flags & LXC_CREATE_QUIET), argv);
+	return c->create(c, t, bdevtype, specs, !!(flags & LXC_CREATE_QUIET), argv);
 }
 
 bool go_lxc_start(struct lxc_container *c, int useinit, char * const argv[]) {

--- a/lxc-binding.h
+++ b/lxc-binding.h
@@ -12,7 +12,7 @@ extern void go_lxc_clear_config(struct lxc_container *c);
 extern bool go_lxc_clear_config_item(struct lxc_container *c, const char *key);
 extern bool go_lxc_clone(struct lxc_container *c, const char *newname, const char *lxcpath, int flags, const char *bdevtype);
 extern bool go_lxc_console(struct lxc_container *c, int ttynum, int stdinfd, int stdoutfd, int stderrfd, int escape);
-extern bool go_lxc_create(struct lxc_container *c, const char *t, const char *bdevtype, int flags, char * const argv[]);
+extern bool go_lxc_create(struct lxc_container *c, const char *t, const char *bdevtype, struct bdev_specs *specs, int flags, char * const argv[]);
 extern bool go_lxc_defined(struct lxc_container *c);
 extern bool go_lxc_destroy(struct lxc_container *c);
 extern bool go_lxc_destroy_with_snapshots(struct lxc_container *c);

--- a/options.go
+++ b/options.go
@@ -71,6 +71,8 @@ type TemplateOptions struct {
 	// Backend specifies the type of the backend.
 	Backend BackendStore
 
+	BackendSpecs *BackendStoreSpecs
+
 	// Distro specifies the name of the distribution.
 	Distro string
 
@@ -104,6 +106,23 @@ type TemplateOptions struct {
 	// ExtraArgs provides a way to specify template specific args.
 	ExtraArgs []string
 }
+
+
+type BackendStoreSpecs struct {
+	FSType string
+	FSSize uint64
+	Dir *string
+	ZFS struct {
+		Root string
+	}
+	LVM struct {
+		VG, LV, Thinpool string
+	}
+	RBD struct {
+		Name, Pool string
+	}
+}
+
 
 // DownloadTemplateOptions is a convenient set of options for "download" template.
 var DownloadTemplateOptions = TemplateOptions{


### PR DESCRIPTION
Closes #43 

It seems bdev_specs are missing from the go binding ( in `go_lxc_create` ). It adds support for passing backing store options from Golang.
 