### PR TITLE
container: implement DevptsFd()

### DIFF
--- a/container.go
+++ b/container.go
@@ -312,6 +312,19 @@ func (c *Container) InitPidFd() (*os.File, error) {
 	return os.NewFile(uintptr(pidfd), "[pidfd]"), nil
 }
 
+// DevptsFd returns the pidfd of the container's init process.
+func (c *Container) DevptsFd() (*os.File, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	devptsFd := int(C.go_lxc_devpts_fd(c.container))
+	if devptsFd < 0 {
+		return nil, unix.Errno(unix.EBADF)
+	}
+
+	return os.NewFile(uintptr(devptsFd), "/dev/pts/ptmx"), nil
+}
+
 // SeccompNotifyFd returns the seccomp notify fd of the container.
 func (c *Container) SeccompNotifyFd() (*os.File, error) {
 	c.mu.RLock()

--- a/lxc-binding.c
+++ b/lxc-binding.c
@@ -67,6 +67,14 @@ int go_lxc_seccomp_notify_fd(struct lxc_container *c) {
 #endif
 }
 
+int go_lxc_devpts_fd(struct lxc_container *c) {
+#if VERSION_AT_LEAST(4, 0, 4)
+	return c->devpts_fd(c);
+#else
+	return ret_errno(ENOSYS);
+#endif
+}
+
 bool go_lxc_want_daemonize(struct lxc_container *c, bool state) {
 	return c->want_daemonize(c, state);
 }

--- a/lxc-binding.h
+++ b/lxc-binding.h
@@ -81,6 +81,7 @@ extern int go_lxc_snapshot_list(struct lxc_container *c, struct lxc_snapshot **r
 extern int go_lxc_snapshot(struct lxc_container *c);
 extern pid_t go_lxc_init_pid(struct lxc_container *c);
 extern int go_lxc_init_pidfd(struct lxc_container *c);
+extern int go_lxc_devpts_fd(struct lxc_container *c);
 extern int go_lxc_seccomp_notify_fd(struct lxc_container *c);
 extern bool go_lxc_checkpoint(struct lxc_container *c, char *directory, bool stop, bool verbose);
 extern bool go_lxc_restore(struct lxc_container *c, char *directory, bool verbose);


### PR DESCRIPTION
which calls into LXC to allocate a new devpts fd for the containers
devpts instance.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>