### PR TITLE
Fixes crash in cgroupItem()

### DIFF
--- a/container.go
+++ b/container.go
@@ -838,6 +838,10 @@ func (c *Container) RunningConfigItem(key string) []string {
 }
 
 func (c *Container) cgroupItem(key string) []string {
+	if c.container == nil {
+		return nil
+	}
+
 	ckey := C.CString(key)
 	defer C.free(unsafe.Pointer(ckey))
 

--- a/options.go
+++ b/options.go
@@ -107,12 +107,11 @@ type TemplateOptions struct {
 	ExtraArgs []string
 }
 
-
 type BackendStoreSpecs struct {
 	FSType string
 	FSSize uint64
-	Dir *string
-	ZFS struct {
+	Dir    *string
+	ZFS    struct {
 		Root string
 	}
 	LVM struct {
@@ -122,7 +121,6 @@ type BackendStoreSpecs struct {
 		Name, Pool string
 	}
 }
-
 
 // DownloadTemplateOptions is a convenient set of options for "download" template.
 var DownloadTemplateOptions = TemplateOptions{


### PR DESCRIPTION
When container is shutting down and `lxc ls` is run, it can crash LXD with stack trace:

```
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0x2380 pc=0x7fe173a817d2]

runtime stack:
runtime.throw(0x159c9bf, 0x2a)
	/usr/lib/go-1.13/src/runtime/panic.go:774 +0x72
runtime.sigpanic()
	/usr/lib/go-1.13/src/runtime/signal_unix.go:378 +0x47c

goroutine 19614 [syscall]:
runtime.cgocall(0x1249fa9, 0xc0000234a8, 0xc0000234b8)
	/usr/lib/go-1.13/src/runtime/cgocall.go:128 +0x5b fp=0xc000023478 sp=0xc000023440 pc=0x41061b
gopkg.in/lxc/go-lxc%2ev2._Cfunc_go_lxc_get_cgroup_item(0x7fe11c005100, 0x7fe140003e30, 0x0)
	_cgo_gotypes.go:674 +0x4e fp=0xc0000234a8 sp=0xc000023478 pc=0x8bd43e
gopkg.in/lxc/go-lxc%2ev2.(*Container).cgroupItem.func2(0xc00032d950, 0x7fe140003e30, 0x7fe140003e30)
	/home/user/go/src/gopkg.in/lxc/go-lxc.v2/container.go:845 +0x69 fp=0xc0000234e8 sp=0xc0000234a8 pc=0x8d0fa9
gopkg.in/lxc/go-lxc%2ev2.(*Container).cgroupItem(0xc00032d950, 0x1578126, 0x19, 0x0, 0x0, 0x0)
	/home/user/go/src/gopkg.in/lxc/go-lxc.v2/container.go:845 +0xc9 fp=0xc0000235c0 sp=0xc0000234e8 pc=0x8c4c59
gopkg.in/lxc/go-lxc%2ev2.(*Container).CgroupItem(0xc00032d950, 0x1578126, 0x19, 0x0, 0x0, 0x0)
	/home/user/go/src/gopkg.in/lxc/go-lxc.v2/container.go:870 +0xa5 fp=0xc000023638 sp=0xc0000235c0 pc=0x8c4fd5
github.com/lxc/lxd/lxd/instance/drivers.(*lxcCgroupReadWriter).Get(0xc000708850, 0x1, 0x1549c59, 0x6, 0x1578126, 0x19, 0xc00019eb08, 0x9, 0x1, 0x1)
	/home/user/go/src/github.com/lxc/lxd/lxd/instance/drivers/driver_lxc.go:7061 +0x1d8 fp=0xc000023690 sp=0xc000023638 pc=0xfa0178
github.com/lxc/lxd/lxd/cgroup.(*CGroup).GetMemoryMaxUsage(0xc0004fa4a0, 0x9, 0xc0004fa4a0, 0x1, 0x3bdf000)
	/home/user/go/src/github.com/lxc/lxd/lxd/cgroup/abstraction.go:155 +0x10e fp=0xc0000236f0 sp=0xc000023690 pc=0xc4b98e
github.com/lxc/lxd/lxd/instance/drivers.(*lxc).memoryState(0xc000034dc0, 0x5dcffb4e, 0x7, 0xc0004783c8, 0x1486080)
	/home/user/go/src/github.com/lxc/lxd/lxd/instance/drivers/driver_lxc.go:5839 +0x2db fp=0xc000023760 sp=0xc0000236f0 pc=0xf975eb
github.com/lxc/lxd/lxd/instance/drivers.(*lxc).RenderState(0xc000034dc0, 0xc000514140, 0x0, 0x0)
	/home/user/go/src/github.com/lxc/lxd/lxd/instance/drivers/driver_lxc.go:3230 +0x891 fp=0xc000023838 sp=0xc000023760 pc=0xf7d151
github.com/lxc/lxd/lxd/instance/drivers.(*lxc).RenderFull(0xc000034dc0, 0xc0007247b0, 0xc0004c6e30, 0x2, 0xc00019ee18, 0xc0009650e0)
	/home/user/go/src/github.com/lxc/lxd/lxd/instance/drivers/driver_lxc.go:3172 +0x167 fp=0xc000023c20 sp=0xc000023838 pc=0xf7c137
main.doContainersGet.func5(0xc00032a9c0, 0xc0005704c0, 0xc0007247b0, 0xc00069c200, 0xc00069c220, 0xc000670b10)
	/home/user/go/src/github.com/lxc/lxd/lxd/instances_get.go:268 +0x228 fp=0xc000023fb0 sp=0xc000023c20 pc=0x121e198
runtime.goexit()
	/usr/lib/go-1.13/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc000023fb8 sp=0xc000023fb0 pc=0x46d091
created by main.doContainersGet
	/home/user/go/src/github.com/lxc/lxd/lxd/instances_get.go:250 +0xc47

goroutine 1 [select, 36 minutes]:
main.(*cmdDaemon).Run(0xc0003900c0, 0xc0001982c0, 0xc0001a1a40, 0x0, 0x4, 0x0, 0x0)
	/home/user/go/src/github.com/lxc/lxd/lxd/main_daemon.go:93 +0x734
github.com/spf13/cobra.(*Command).execute(0xc0001982c0, 0xc000032060, 0x4, 0x4, 0xc0001982c0, 0xc000032060)
	/home/user/go/src/github.com/spf13/cobra/command.go:850 +0x460
github.com/spf13/cobra.(*Command).ExecuteC(0xc0001982c0, 0xc00037bf30, 0x1, 0x1)
	/home/user/go/src/github.com/spf13/cobra/command.go:958 +0x349
github.com/spf13/cobra.(*Command).Execute(...)
	/home/user/go/src/github.com/spf13/cobra/command.go:895
main.main()
	/home/user/go/src/github.com/lxc/lxd/lxd/main.go:213 +0xf3b

goroutine 76 [select, 36 minutes]:
database/sql.(*DB).connectionResetter(0xc00025a300, 0x180b9a0, 0xc000083640)
	/usr/lib/go-1.13/src/database/sql/sql.go:1065 +0xfb
created by database/sql.OpenDB
	/usr/lib/go-1.13/src/database/sql/sql.go:723 +0x193

goroutine 23 [syscall, 36 minutes]:
os/signal.signal_recv(0x0)
	/usr/lib/go-1.13/src/runtime/sigqueue.go:147 +0x9c
os/signal.loop()
	/usr/lib/go-1.13/src/os/signal/signal_unix.go:23 +0x22
created by os/signal.init.0
	/usr/lib/go-1.13/src/os/signal/signal_unix.go:29 +0x41

goroutine 19612 [runnable]:
syscall.Syscall(0x0, 0x10, 0xc000570060, 0x8, 0x8, 0x8, 0x0)
	/usr/lib/go-1.13/src/syscall/asm_linux_amd64.s:18 +0x5
syscall.read(0x10, 0xc000570060, 0x8, 0x8, 0x0, 0x17e2c40, 0x2147fb8)
	/usr/lib/go-1.13/src/syscall/zsyscall_linux_amd64.go:732 +0x5a
syscall.Read(...)
	/usr/lib/go-1.13/src/syscall/syscall_unix.go:183
internal/poll.(*FD).Read(0xc0000f9180, 0xc000570060, 0x8, 0x8, 0x0, 0x0, 0x0)
	/usr/lib/go-1.13/src/internal/poll/fd_unix.go:165 +0x164
net.(*netFD).Read(0xc0000f9180, 0xc000570060, 0x8, 0x8, 0xc0008387b8, 0x5bcd8f, 0xc0000f9180)
	/usr/lib/go-1.13/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc000184258, 0xc000570060, 0x8, 0x8, 0x0, 0x0, 0x0)
	/usr/lib/go-1.13/src/net/net.go:184 +0x68
github.com/canonical/go-dqlite/internal/protocol.(*Protocol).recvFill(0xc000083700, 0xc000570060, 0x8, 0x8, 0x64, 0xc000838860, 0xc000838868)
	/home/user/go/src/github.com/canonical/go-dqlite/internal/protocol/protocol.go:226 +0x74
github.com/canonical/go-dqlite/internal/protocol.(*Protocol).recvPeek(0xc000083700, 0xc000570060, 0x8, 0x8, 0x0, 0xb0)
	/home/user/go/src/github.com/canonical/go-dqlite/internal/protocol/protocol.go:210 +0x9c
github.com/canonical/go-dqlite/internal/protocol.(*Protocol).recvHeader(0xc000083700, 0xc0000c4aa0, 0x0, 0x0)
	/home/user/go/src/github.com/canonical/go-dqlite/internal/protocol/protocol.go:177 +0x4f
github.com/canonical/go-dqlite/internal/protocol.(*Protocol).recv(0xc000083700, 0xc0000c4aa0, 0x0, 0x0)
	/home/user/go/src/github.com/canonical/go-dqlite/internal/protocol/protocol.go:165 +0x47
github.com/canonical/go-dqlite/internal/protocol.(*Protocol).Call(0xc000083700, 0x180b9e0, 0xc00003a0f0, 0xc0000c4a60, 0xc0000c4aa0, 0x0, 0x0)
	/home/user/go/src/github.com/canonical/go-dqlite/internal/protocol/protocol.go:70 +0x1d3
github.com/canonical/go-dqlite/driver.(*Conn).QueryContext(0xc0000c4a50, 0x180b9e0, 0xc00003a0f0, 0x15c1da6, 0x93, 0xc000724ea0, 0x1, 0x1, 0xc0005b0000, 0x10, ...)
	/home/user/go/src/github.com/canonical/go-dqlite/driver/driver.go:398 +0xdc
database/sql.ctxDriverQuery(0x180b9e0, 0xc00003a0f0, 0x7fe170059028, 0xc0000c4a50, 0x0, 0x0, 0x15c1da6, 0x93, 0xc000724ea0, 0x1, ...)
	/usr/lib/go-1.13/src/database/sql/ctxutil.go:48 +0x227
database/sql.(*DB).queryDC.func1()
	/usr/lib/go-1.13/src/database/sql/sql.go:1592 +0x1db
database/sql.withLock(0x17f4460, 0xc0000f8080, 0xc000838df0)
	/usr/lib/go-1.13/src/database/sql/sql.go:3184 +0x6d
database/sql.(*DB).queryDC(0xc00025a300, 0x180b9e0, 0xc00003a0f0, 0x180b9a0, 0xc000935180, 0xc0000f8080, 0xc0005a7c70, 0x15c1da6, 0x93, 0xc0008390c0, ...)
	/usr/lib/go-1.13/src/database/sql/sql.go:1587 +0x5dd
database/sql.(*Tx).QueryContext(0xc000193880, 0x180b9e0, 0xc00003a0f0, 0x15c1da6, 0x93, 0xc0008390c0, 0x1, 0x1, 0x0, 0x13e0c40, ...)
	/usr/lib/go-1.13/src/database/sql/sql.go:2291 +0x116
database/sql.(*Tx).Query(...)
	/usr/lib/go-1.13/src/database/sql/sql.go:2296
github.com/lxc/lxd/lxd/db/query.scanSingleColumn(0xc000193880, 0x15c1da6, 0x93, 0xc0008390c0, 0x1, 0x1, 0x1545458, 0x4, 0xc000839018, 0x0, ...)
	/home/user/go/src/github.com/lxc/lxd/lxd/db/query/slices.go:127 +0xa5
github.com/lxc/lxd/lxd/db/query.SelectStrings(0xc000193880, 0x15c1da6, 0x93, 0xc0008390c0, 0x1, 0x1, 0xc0000f8080, 0xc0008390f8, 0x8419d9, 0xc00025a300, ...)
	/home/user/go/src/github.com/lxc/lxd/lxd/db/query/slices.go:70 +0xcf
github.com/lxc/lxd/lxd/db.(*Cluster).storagePoolNodes.func1(0xc0003c9620, 0xc000193880, 0x0)
	/home/user/go/src/github.com/lxc/lxd/lxd/db/storage_pools.go:701 +0xb9
github.com/lxc/lxd/lxd/db.(*Cluster).transaction.func1.1(0xc000193880, 0x180b9e0, 0xc00003a0f0)
	/home/user/go/src/github.com/lxc/lxd/lxd/db/db.go:391 +0x41
github.com/lxc/lxd/lxd/db/query.Transaction(0xc00025a300, 0xc0008391b0, 0xc0003c9620, 0x20)
	/home/user/go/src/github.com/lxc/lxd/lxd/db/query/transaction.go:23 +0x170
github.com/lxc/lxd/lxd/db.(*Cluster).transaction.func1(0x18, 0xc0003c9620)
	/home/user/go/src/github.com/lxc/lxd/lxd/db/db.go:389 +0x66
github.com/lxc/lxd/lxd/db/query.Retry(0xc000839290, 0x20, 0x14346e0)
	/home/user/go/src/github.com/lxc/lxd/lxd/db/query/retry.go:26 +0xe0
github.com/lxc/lxd/lxd/db.(*Cluster).retry(0xc00018a200, 0xc000839290, 0x203000, 0x203000)
	/home/user/go/src/github.com/lxc/lxd/lxd/db/db.go:404 +0x92
github.com/lxc/lxd/lxd/db.(*Cluster).transaction(0xc00018a200, 0xc000839360, 0x80, 0x78)
	/home/user/go/src/github.com/lxc/lxd/lxd/db/db.go:388 +0x94
github.com/lxc/lxd/lxd/db.(*Cluster).Transaction(0xc00018a200, 0xc000839360, 0x0, 0x0)
	/home/user/go/src/github.com/lxc/lxd/lxd/db/db.go:351 +0x85
github.com/lxc/lxd/lxd/db.(*Cluster).storagePoolNodes(0xc00018a200, 0x1, 0xc000724e70, 0x0, 0x0, 0x2, 0xc000839460)
	/home/user/go/src/github.com/lxc/lxd/lxd/db/storage_pools.go:699 +0x92
github.com/lxc/lxd/lxd/db.(*Cluster).getStoragePool(0xc00018a200, 0xc000570945, 0x7, 0x1, 0x8, 0xc0008394b0, 0x944019, 0x0)
	/home/user/go/src/github.com/lxc/lxd/lxd/db/storage_pools.go:682 +0x42c
github.com/lxc/lxd/lxd/db.(*Cluster).GetStoragePool(...)
	/home/user/go/src/github.com/lxc/lxd/lxd/db/storage_pools.go:626
github.com/lxc/lxd/lxd/storage.GetPoolByName(0xc000183920, 0xc000570945, 0x7, 0xc0005705f0, 0x5, 0xc000570945, 0x7)
	/home/user/go/src/github.com/lxc/lxd/lxd/storage/load.go:143 +0x33f
github.com/lxc/lxd/lxd/storage.GetPoolByInstance(0xc000183920, 0x184bd20, 0xc000034f00, 0x4, 0xc00019e408, 0xc000254cb0, 0xc000839678)
	/home/user/go/src/github.com/lxc/lxd/lxd/storage/load.go:182 +0xf8
github.com/lxc/lxd/lxd/instance/drivers.(*lxc).diskState(0xc000034f00, 0x154b55a)
	/home/user/go/src/github.com/lxc/lxd/lxd/instance/drivers/driver_lxc.go:5782 +0x1a1
github.com/lxc/lxd/lxd/instance/drivers.(*lxc).RenderState(0xc000034f00, 0xc0005e0140, 0x0, 0x0)
	/home/user/go/src/github.com/lxc/lxd/lxd/instance/drivers/driver_lxc.go:3235 +0x7fc
github.com/lxc/lxd/lxd/instance/drivers.(*lxc).RenderFull(0xc000034f00, 0xc0007247b0, 0xc0004c6dc0, 0x5, 0xc00019ee28, 0x180ba60)
	/home/user/go/src/github.com/lxc/lxd/lxd/instance/drivers/driver_lxc.go:3172 +0x167
main.doContainersGet.func5(0xc00032a9c0, 0xc0005704c0, 0xc0007247b0, 0xc00069c200, 0xc00069c220, 0xc000670b10)
	/home/user/go/src/github.com/lxc/lxd/lxd/instances_get.go:268 +0x228
created by main.doContainersGet
	/home/user/go/src/github.com/lxc/lxd/lxd/instances_get.go:250 +0xc47

goroutine 25 [select, 36 minutes]:
database/sql.(*DB).connectionResetter(0xc00035c6c0, 0x180b9a0, 0xc0003b0c40)
	/usr/lib/go-1.13/src/database/sql/sql.go:1065 +0xfb
created by database/sql.OpenDB
	/usr/lib/go-1.13/src/database/sql/sql.go:723 +0x193

goroutine 24 [select, 36 minutes]:
database/sql.(*DB).connectionOpener(0xc00035c6c0, 0x180b9a0, 0xc0003b0c40)
	/usr/lib/go-1.13/src/database/sql/sql.go:1052 +0xe8
created by database/sql.OpenDB
	/usr/lib/go-1.13/src/database/sql/sql.go:722 +0x15d

goroutine 19605 [IO wait]:
internal/poll.runtime_pollWait(0x7fe1701dfa28, 0x72, 0xffffffffffffffff)
	/usr/lib/go-1.13/src/runtime/netpoll.go:184 +0x55
internal/poll.(*pollDesc).wait(0xc0000f8118, 0x72, 0x0, 0x1, 0xffffffffffffffff)
	/usr/lib/go-1.13/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/lib/go-1.13/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc0000f8100, 0xc000327d51, 0x1, 0x1, 0x0, 0x0, 0x0)
	/usr/lib/go-1.13/src/internal/poll/fd_unix.go:169 +0x1cf
net.(*netFD).Read(0xc0000f8100, 0xc000327d51, 0x1, 0x1, 0xc0001a8f88, 0xc0013461d8, 0xc0001a9038)
	/usr/lib/go-1.13/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc0001ca118, 0xc000327d51, 0x1, 0x1, 0x0, 0x0, 0x0)
	/usr/lib/go-1.13/src/net/net.go:184 +0x68
net/http.(*connReader).backgroundRead(0xc000327d40)
	/usr/lib/go-1.13/src/net/http/server.go:677 +0x58
created by net/http.(*connReader).startBackgroundRead
	/usr/lib/go-1.13/src/net/http/server.go:673 +0xd4

goroutine 75 [select, 36 minutes]:
database/sql.(*DB).connectionOpener(0xc00025a300, 0x180b9a0, 0xc000083640)
	/usr/lib/go-1.13/src/database/sql/sql.go:1052 +0xe8
created by database/sql.OpenDB
	/usr/lib/go-1.13/src/database/sql/sql.go:722 +0x15d

goroutine 72 [IO wait]:
internal/poll.runtime_pollWait(0x7fe1701dff08, 0x72, 0x0)
	/usr/lib/go-1.13/src/runtime/netpoll.go:184 +0x55
internal/poll.(*pollDesc).wait(0xc0000f8698, 0x72, 0x0, 0x0, 0x154b7bb)
	/usr/lib/go-1.13/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/lib/go-1.13/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Accept(0xc0000f8680, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/lib/go-1.13/src/internal/poll/fd_unix.go:384 +0x1f8
net.(*netFD).accept(0xc0000f8680, 0x7039a4, 0xc0003040a0, 0xc000acb8c0)
	/usr/lib/go-1.13/src/net/fd_unix.go:238 +0x42
net.(*UnixListener).accept(0xc000530b70, 0x5f803b50, 0xc000069d70, 0x4e0bb6)
	/usr/lib/go-1.13/src/net/unixsock_posix.go:162 +0x32
net.(*UnixListener).Accept(0xc000530b70, 0xc000069dc0, 0x18, 0xc0001a9380, 0x702ed4)
	/usr/lib/go-1.13/src/net/unixsock.go:260 +0x47
net/http.(*Server).Serve(0xc000304000, 0x18042e0, 0xc000530b70, 0x0, 0x0)
	/usr/lib/go-1.13/src/net/http/server.go:2896 +0x280
github.com/lxc/lxd/lxd/endpoints.(*Endpoints).serveHTTP.func1(0x0, 0x1)
	/home/user/go/src/github.com/lxc/lxd/lxd/endpoints/endpoints.go:342 +0x3c
gopkg.in/tomb%2ev2.(*Tomb).run(0xc000032be0, 0xc0005383e0)
	/home/user/go/src/gopkg.in/tomb.v2/tomb.go:163 +0x2b
created by gopkg.in/tomb%2ev2.(*Tomb).Go
	/home/user/go/src/gopkg.in/tomb.v2/tomb.go:159 +0xc7

goroutine 71 [IO wait, 36 minutes]:
internal/poll.runtime_pollWait(0x7fe1701dfe38, 0x72, 0x0)
	/usr/lib/go-1.13/src/runtime/netpoll.go:184 +0x55
internal/poll.(*pollDesc).wait(0xc0000f8818, 0x72, 0x0, 0x0, 0x154b7bb)
	/usr/lib/go-1.13/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/lib/go-1.13/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Accept(0xc0000f8800, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/lib/go-1.13/src/internal/poll/fd_unix.go:384 +0x1f8
net.(*netFD).accept(0xc0000f8800, 0xc0001b6a80, 0x7fe173455460, 0xc0001a9500)
	/usr/lib/go-1.13/src/net/fd_unix.go:238 +0x42
net.(*UnixListener).accept(0xc000530bd0, 0xc00006bd70, 0x41a458, 0x30)
	/usr/lib/go-1.13/src/net/unixsock_posix.go:162 +0x32
net.(*UnixListener).Accept(0xc000530bd0, 0x1489f60, 0xc0005461b0, 0x138e3c0, 0x21254d0)
	/usr/lib/go-1.13/src/net/unixsock.go:260 +0x47
net/http.(*Server).Serve(0xc0003040e0, 0x18042e0, 0xc000530bd0, 0x0, 0x0)
	/usr/lib/go-1.13/src/net/http/server.go:2896 +0x280
github.com/lxc/lxd/lxd/endpoints.(*Endpoints).serveHTTP.func1(0x0, 0xc0001ebf98)
	/home/user/go/src/github.com/lxc/lxd/lxd/endpoints/endpoints.go:342 +0x3c
gopkg.in/tomb%2ev2.(*Tomb).run(0xc000032be0, 0xc000538320)
	/home/user/go/src/gopkg.in/tomb.v2/tomb.go:163 +0x2b
created by gopkg.in/tomb%2ev2.(*Tomb).Go
	/home/user/go/src/gopkg.in/tomb.v2/tomb.go:159 +0xc7

goroutine 310 [syscall, 36 minutes]:
syscall.Syscall(0x0, 0x16, 0xc000604000, 0x64640, 0x45389c, 0x66000, 0x1331be0)
	/usr/lib/go-1.13/src/syscall/asm_linux_amd64.s:18 +0x5
golang.org/x/sys/unix.read(0x16, 0xc000604000, 0x64640, 0x64640, 0xc0003edfb0, 0x1, 0x78b0f9)
	/home/user/go/src/golang.org/x/sys/unix/zsyscall_linux.go:1231 +0x5a
golang.org/x/sys/unix.Read(...)
	/home/user/go/src/golang.org/x/sys/unix/syscall_unix.go:156
github.com/lxc/lxd/lxd/device.inotifyWatcher.func1(0xc000566a20, 0xc0001d8180)
	/home/user/go/src/github.com/lxc/lxd/lxd/device/device_utils_inotify.go:170 +0x7d
created by github.com/lxc/lxd/lxd/device.inotifyWatcher
	/home/user/go/src/github.com/lxc/lxd/lxd/device/device_utils_inotify.go:167 +0x67

goroutine 19642 [chan receive]:
database/sql.(*Tx).awaitDone(0xc000193880)
	/usr/lib/go-1.13/src/database/sql/sql.go:2002 +0x4b
created by database/sql.(*DB).beginDC
	/usr/lib/go-1.13/src/database/sql/sql.go:1723 +0x1b4

goroutine 301 [syscall]:
syscall.Syscall(0x0, 0x17, 0xc00039d000, 0x1000, 0x1, 0xc00056eea8, 0x133c880)
	/usr/lib/go-1.13/src/syscall/asm_linux_amd64.s:18 +0x5
golang.org/x/sys/unix.read(0x17, 0xc00039d000, 0x1000, 0x1000, 0x26e0500, 0x0, 0x5)
	/home/user/go/src/golang.org/x/sys/unix/zsyscall_linux.go:1231 +0x5a
golang.org/x/sys/unix.Read(...)
	/home/user/go/src/golang.org/x/sys/unix/syscall_unix.go:156
main.deviceNetlinkListener.func1(0x800, 0x17, 0xc000295f80, 0xc0001a4180, 0xc0001a41e0, 0xc0001a4240)
	/home/user/go/src/github.com/lxc/lxd/lxd/devices.go:102 +0x9f
created by main.deviceNetlinkListener
	/home/user/go/src/github.com/lxc/lxd/lxd/devices.go:99 +0x210

goroutine 19613 [runnable]:
gopkg.in/lxc/go-lxc%2ev2._Cfunc_free(0x7fe14c006430)
	_cgo_gotypes.go:272 +0x41
gopkg.in/lxc/go-lxc%2ev2.(*Container).cgroupItem.func3.1()
	/home/user/go/src/gopkg.in/lxc/go-lxc.v2/container.go:846 +0x5a
gopkg.in/lxc/go-lxc%2ev2.(*Container).cgroupItem(0xc000965170, 0x1578126, 0x19, 0xc0006f9b80, 0x1, 0x1)
	/home/user/go/src/gopkg.in/lxc/go-lxc.v2/container.go:849 +0x198
gopkg.in/lxc/go-lxc%2ev2.(*Container).CgroupItem(0xc000965170, 0x1578126, 0x19, 0x0, 0x0, 0x0)
	/home/user/go/src/gopkg.in/lxc/go-lxc.v2/container.go:870 +0xa5
github.com/lxc/lxd/lxd/instance/drivers.(*lxcCgroupReadWriter).Get(0xc0006f9b00, 0x1, 0x1549c59, 0x6, 0x1578126, 0x19, 0xc00019eb08, 0x9, 0x1, 0x1)
	/home/user/go/src/github.com/lxc/lxd/lxd/instance/drivers/driver_lxc.go:7061 +0x1d8
github.com/lxc/lxd/lxd/cgroup.(*CGroup).GetMemoryMaxUsage(0xc00069c700, 0x9, 0xc00069c700, 0x1, 0x362c000)
	/home/user/go/src/github.com/lxc/lxd/lxd/cgroup/abstraction.go:155 +0x10e
github.com/lxc/lxd/lxd/instance/drivers.(*lxc).memoryState(0xc000034b40, 0x4ebe5964, 0x7, 0xc0001daba8, 0x1486080)
	/home/user/go/src/github.com/lxc/lxd/lxd/instance/drivers/driver_lxc.go:5839 +0x2db
github.com/lxc/lxd/lxd/instance/drivers.(*lxc).RenderState(0xc000034b40, 0xc0004f08c0, 0x0, 0x0)
	/home/user/go/src/github.com/lxc/lxd/lxd/instance/drivers/driver_lxc.go:3230 +0x891
github.com/lxc/lxd/lxd/instance/drivers.(*lxc).RenderFull(0xc000034b40, 0xc0007247b0, 0xc0004c6e10, 0x2, 0xc00019ee08, 0x41ba2d)
	/home/user/go/src/github.com/lxc/lxd/lxd/instance/drivers/driver_lxc.go:3172 +0x167
main.doContainersGet.func5(0xc00032a9c0, 0xc0005704c0, 0xc0007247b0, 0xc00069c200, 0xc00069c220, 0xc000670b10)
	/home/user/go/src/github.com/lxc/lxd/lxd/instances_get.go:268 +0x228
created by main.doContainersGet
	/home/user/go/src/github.com/lxc/lxd/lxd/instances_get.go:250 +0xc47

goroutine 391 [select, 36 minutes]:
github.com/lxc/lxd/lxd/task.(*Task).loop(0xc000390b60, 0x180b9a0, 0xc0005fa200)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/task.go:66 +0x153
github.com/lxc/lxd/lxd/task.(*Group).Start.func1(0xc000390b60, 0xc000544ac0, 0xc0001a87e8, 0x0)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:61 +0x45
created by github.com/lxc/lxd/lxd/task.(*Group).Start
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:60 +0x259

goroutine 392 [select, 36 minutes]:
github.com/lxc/lxd/lxd/task.(*Task).loop(0xc000390b80, 0x180b9a0, 0xc0005fa200)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/task.go:66 +0x153
github.com/lxc/lxd/lxd/task.(*Group).Start.func1(0xc000390b80, 0xc000544ac0, 0xc0001a87e8, 0x1)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:61 +0x45
created by github.com/lxc/lxd/lxd/task.(*Group).Start
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:60 +0x259

goroutine 341 [chan receive, 36 minutes]:
github.com/lxc/lxd/lxd/device.InotifyHandler(0xc000566a20)
	/home/user/go/src/github.com/lxc/lxd/lxd/device/device_utils_inotify.go:52 +0x56
created by main.(*Daemon).init
	/home/user/go/src/github.com/lxc/lxd/lxd/daemon.go:1056 +0x2096

goroutine 317 [IO wait, 36 minutes]:
internal/poll.runtime_pollWait(0x7fe1701dfaf8, 0x72, 0x0)
	/usr/lib/go-1.13/src/runtime/netpoll.go:184 +0x55
internal/poll.(*pollDesc).wait(0xc000192a98, 0x72, 0x0, 0x0, 0x154b7bb)
	/usr/lib/go-1.13/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/lib/go-1.13/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Accept(0xc000192a80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/lib/go-1.13/src/internal/poll/fd_unix.go:384 +0x1f8
net.(*netFD).accept(0xc000192a80, 0x3, 0x0, 0x1608bb0)
	/usr/lib/go-1.13/src/net/fd_unix.go:238 +0x42
net.(*UnixListener).accept(0xc0004e5560, 0xc000080138, 0x466dc0, 0xc0000800e0)
	/usr/lib/go-1.13/src/net/unixsock_posix.go:162 +0x32
net.(*UnixListener).Accept(0xc0004e5560, 0xfcff6d, 0x445116, 0x1608900, 0xfcff6d)
	/usr/lib/go-1.13/src/net/unixsock.go:260 +0x47
github.com/lxc/lxd/lxd/seccomp.NewSeccompServer.func1(0x18042e0, 0xc0004e5560, 0xc0004e5590, 0x16078a8)
	/home/user/go/src/github.com/lxc/lxd/lxd/seccomp/seccomp.go:989 +0x69
created by github.com/lxc/lxd/lxd/seccomp.NewSeccompServer
	/home/user/go/src/github.com/lxc/lxd/lxd/seccomp/seccomp.go:987 +0x1cb

goroutine 340 [select]:
main.deviceEventListener(0xc000566960)
	/home/user/go/src/github.com/lxc/lxd/lxd/devices.go:526 +0x226
created by main.(*Daemon).init
	/home/user/go/src/github.com/lxc/lxd/lxd/daemon.go:1048 +0x1f30

goroutine 393 [select, 36 minutes]:
github.com/lxc/lxd/lxd/task.(*Task).loop(0xc000390ba0, 0x180b9a0, 0xc0005fa200)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/task.go:66 +0x153
github.com/lxc/lxd/lxd/task.(*Group).Start.func1(0xc000390ba0, 0xc000544ac0, 0xc0001a87e8, 0x2)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:61 +0x45
created by github.com/lxc/lxd/lxd/task.(*Group).Start
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:60 +0x259

goroutine 394 [select, 36 minutes]:
github.com/lxc/lxd/lxd/task.(*Task).loop(0xc000390bc0, 0x180b9a0, 0xc0005fa200)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/task.go:66 +0x153
github.com/lxc/lxd/lxd/task.(*Group).Start.func1(0xc000390bc0, 0xc000544ac0, 0xc0001a87e8, 0x3)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:61 +0x45
created by github.com/lxc/lxd/lxd/task.(*Group).Start
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:60 +0x259

goroutine 395 [select, 36 minutes]:
github.com/lxc/lxd/lxd/task.(*Task).loop(0xc000390be0, 0x180b9a0, 0xc0005fa200)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/task.go:66 +0x153
github.com/lxc/lxd/lxd/task.(*Group).Start.func1(0xc000390be0, 0xc000544ac0, 0xc0001a87e8, 0x4)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:61 +0x45
created by github.com/lxc/lxd/lxd/task.(*Group).Start
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:60 +0x259

goroutine 396 [select]:
github.com/lxc/lxd/lxd/task.(*Task).loop(0xc000390c00, 0x180b9a0, 0xc0005fa200)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/task.go:66 +0x153
github.com/lxc/lxd/lxd/task.(*Group).Start.func1(0xc000390c00, 0xc000544ac0, 0xc0001a87e8, 0x5)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:61 +0x45
created by github.com/lxc/lxd/lxd/task.(*Group).Start
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:60 +0x259

goroutine 397 [select]:
github.com/lxc/lxd/lxd/task.(*Task).loop(0xc000390c20, 0x180b9a0, 0xc0005fa200)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/task.go:66 +0x153
github.com/lxc/lxd/lxd/task.(*Group).Start.func1(0xc000390c20, 0xc000544ac0, 0xc0001a87e8, 0x6)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:61 +0x45
created by github.com/lxc/lxd/lxd/task.(*Group).Start
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:60 +0x259

goroutine 398 [select]:
github.com/lxc/lxd/lxd/task.(*Task).loop(0xc000390c40, 0x180b9a0, 0xc0005fa200)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/task.go:66 +0x153
github.com/lxc/lxd/lxd/task.(*Group).Start.func1(0xc000390c40, 0xc000544ac0, 0xc0001a87e8, 0x7)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:61 +0x45
created by github.com/lxc/lxd/lxd/task.(*Group).Start
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:60 +0x259

goroutine 399 [select]:
github.com/lxc/lxd/lxd/task.(*Task).loop(0xc000390c60, 0x180b9a0, 0xc0005fa200)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/task.go:66 +0x153
github.com/lxc/lxd/lxd/task.(*Group).Start.func1(0xc000390c60, 0xc000544ac0, 0xc0001a87e8, 0x8)
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:61 +0x45
created by github.com/lxc/lxd/lxd/task.(*Group).Start
	/home/user/go/src/github.com/lxc/lxd/lxd/task/group.go:60 +0x259

goroutine 9660 [syscall, 16 minutes]:
syscall.Syscall6(0xf7, 0x1, 0x13b85, 0xc000473e70, 0x1000004, 0x0, 0x0, 0xc000473e98, 0x41a458, 0x10)
	/usr/lib/go-1.13/src/syscall/asm_linux_amd64.s:44 +0x5
os.(*Process).blockUntilWaitable(0xc000338ea0, 0x846a51, 0xc001031100, 0x17dfe60)
	/usr/lib/go-1.13/src/os/wait_waitid.go:31 +0x98
os.(*Process).wait(0xc000338ea0, 0x1, 0x0, 0x0)
	/usr/lib/go-1.13/src/os/exec_unix.go:22 +0x39
os.(*Process).Wait(...)
	/usr/lib/go-1.13/src/os/exec.go:125
github.com/lxc/lxd/shared/subprocess.(*Process).start.func1(0xc0002426e0, 0xc0005db220)
	/home/user/go/src/github.com/lxc/lxd/shared/subprocess/proc.go:170 +0x36
created by github.com/lxc/lxd/shared/subprocess.(*Process).start
	/home/user/go/src/github.com/lxc/lxd/shared/subprocess/proc.go:169 +0x380

goroutine 19604 [semacquire]:
sync.runtime_Semacquire(0xc000670b18)
	/usr/lib/go-1.13/src/runtime/sema.go:56 +0x42
sync.(*WaitGroup).Wait(0xc000670b10)
	/usr/lib/go-1.13/src/sync/waitgroup.go:130 +0x64
main.doContainersGet(0xc0001a8780, 0xc0001acb00, 0x18, 0x1400fe0, 0x8, 0xc000027828)
	/home/user/go/src/github.com/lxc/lxd/lxd/instances_get.go:287 +0xf17
main.containersGet(0xc0001a8780, 0xc0001acb00, 0x17f4ee0, 0x2130220)
	/home/user/go/src/github.com/lxc/lxd/lxd/instances_get.go:49 +0x75
main.(*Daemon).createCmd.func1.2(0x1607ba8, 0xc000179be0, 0x1544700, 0x3, 0xffffffffffffffff)
	/home/user/go/src/github.com/lxc/lxd/lxd/daemon.go:505 +0x66
main.(*Daemon).createCmd.func1(0x1804560, 0xc0000fc000, 0xc0001aca00)
	/home/user/go/src/github.com/lxc/lxd/lxd/daemon.go:510 +0xd18
net/http.HandlerFunc.ServeHTTP(0xc0003ce870, 0x1804560, 0xc0000fc000, 0xc0001aca00)
	/usr/lib/go-1.13/src/net/http/server.go:2007 +0x44
github.com/gorilla/mux.(*Router).ServeHTTP(0xc00035c000, 0x1804560, 0xc0000fc000, 0xc0000fa000)
	/home/user/go/src/github.com/gorilla/mux/mux.go:210 +0xe2
main.(*lxdHttpServer).ServeHTTP(0xc00032e860, 0x1804560, 0xc0000fc000, 0xc0000fa000)
	/home/user/go/src/github.com/lxc/lxd/lxd/api.go:91 +0x89
net/http.serverHandler.ServeHTTP(0xc000304000, 0x1804560, 0xc0000fc000, 0xc0000fa000)
	/usr/lib/go-1.13/src/net/http/server.go:2802 +0xa4
net/http.(*conn).serve(0xc00053e140, 0x180b9a0, 0xc000082080)
	/usr/lib/go-1.13/src/net/http/server.go:1890 +0x875
created by net/http.(*Server).Serve
	/usr/lib/go-1.13/src/net/http/server.go:2928 +0x384
```