### PR TITLE
static build: add libcrypto to pkg-config libs

### DIFF
--- a/linking_static.go
+++ b/linking_static.go
@@ -7,6 +7,6 @@
 package lxc
 
 // #cgo CFLAGS: -std=gnu11 -Wvla -Werror
-// #cgo pkg-config: --static lxc
+// #cgo pkg-config: --static lxc libcrypto
 // #cgo LDFLAGS: -static
 import "C"


### PR DESCRIPTION
lxc only asks for -lcrypto (in both --static and dynamic modes):

~ pkg-config --static --libs lxc
-L/usr/local/lib -llxc -lutil -lcap -lseccomp -lssl -lcrypto -lselinux

However, libcrypto wants some additional libraries in --static mode:

~ pkg-config --static --libs libcrypto
-lcrypto -ldl -pthread
~ pkg-config --libs libcrypto
-lcrypto

So let's add libcrypto's pkgconfig to the list of things we depend on for the
static build.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>