### PR TITLE
container: Fix 32bit build

### DIFF
--- a/container.go
+++ b/container.go
@@ -295,7 +295,7 @@ func (c *Container) Snapshots() ([]Snapshot, error) {
 		return nil, ErrNoSnapshot
 	}
 
-	gosnapshots := (*[(1 << 30) - 1]C.struct_lxc_snapshot)(unsafe.Pointer(csnapshots))[:size:size]
+	gosnapshots := (*[(1 << 26) - 1]C.struct_lxc_snapshot)(unsafe.Pointer(csnapshots))[:size:size]
 	snapshots := make([]Snapshot, size, size)
 	for i := 0; i < size; i++ {
 		snapshots[i] = Snapshot{

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/lxc/go-lxc
 
 go 1.16
 
-require golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4
+require golang.org/x/sys v0.0.0-20210324051608-47abb6519492

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 h1:EZ2mChiOa8udjfp6rRmswTbtZN/QzUQp4ptM4rnjHvc=
-golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210324051608-47abb6519492 h1:Paq34FxTluEPvVyayQqMPgHm+vTOrIifmcYxFBx9TLg=
+golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Reduce memory allocation for snapshots to allow building on 32bit.
This will limit the total number of snapshots that this can handle but
it's still such a ludicrous number that it shouldn't be an issue until
we can fully ignore 32bit.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>