### PR TITLE
attach: Add options RemountSysProc and ElevatedPrivileges

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/lxc/go-lxc
 
 go 1.16
 
-require golang.org/x/sys v0.0.0-20210324051608-47abb6519492
+require golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20210324051608-47abb6519492 h1:Paq34FxTluEPvVyayQqMPgHm+vTOrIifmcYxFBx9TLg=
-golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6 h1:cdsMqa2nXzqlgs183pHxtvoVwU7CyzaCTAUOg94af4c=
+golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/lxc-binding.c
+++ b/lxc-binding.c
@@ -295,10 +295,13 @@ int go_lxc_attach_no_wait(struct lxc_container *c,
 		char **extra_env_vars,
 		char **extra_keep_env,
 		const char * const argv[],
-		pid_t *attached_pid) {
+		pid_t *attached_pid,
+		int attach_flags) {
 	int ret;
 
 	lxc_attach_options_t attach_options = LXC_ATTACH_OPTIONS_DEFAULT;
+	attach_options.attach_flags = attach_flags;
+
 	lxc_attach_command_t command = (lxc_attach_command_t){.program = NULL};
 
 	attach_options.env_policy = LXC_ATTACH_KEEP_ENV;
@@ -344,11 +347,13 @@ int go_lxc_attach(struct lxc_container *c,
 		int stdinfd, int stdoutfd, int stderrfd,
 		char *initial_cwd,
 		char **extra_env_vars,
-		char **extra_keep_env) {
+		char **extra_keep_env,
+		int attach_flags) {
 	int ret;
 	pid_t pid;
 
 	lxc_attach_options_t attach_options = LXC_ATTACH_OPTIONS_DEFAULT;
+	attach_options.attach_flags = attach_flags;
 
 	attach_options.env_policy = LXC_ATTACH_KEEP_ENV;
 	if (clear_env) {
@@ -375,16 +380,6 @@ int go_lxc_attach(struct lxc_container *c,
 	attach_options.extra_env_vars = extra_env_vars;
 	attach_options.extra_keep_env = extra_keep_env;
 
-	/*
-	   remount_sys_proc
-	   When using -s and the mount namespace is not included, this flag will cause lxc-attach to remount /proc and /sys to reflect the current other namespace contexts.
-	   default_options.attach_flags |= LXC_ATTACH_REMOUNT_PROC_SYS;
-
-	   elevated_privileges
-	   Do  not  drop privileges when running command inside the container. If this option is specified, the new process will not be added to the container's cgroup(s) and it will not drop its capabilities before executing.
-	   default_options.attach_flags &= ~(LXC_ATTACH_MOVE_TO_CGROUP | LXC_ATTACH_DROP_CAPABILITIES | LXC_ATTACH_APPARMOR);
-	   */
-
 	ret = c->attach(c, lxc_attach_run_shell, NULL, &attach_options, &pid);
 	if (ret < 0)
 		return ret;
@@ -408,10 +403,12 @@ int go_lxc_attach_run_wait(struct lxc_container *c,
 		char *initial_cwd,
 		char **extra_env_vars,
 		char **extra_keep_env,
-		const char * const argv[]) {
+		const char * const argv[],
+		int attach_flags) {
 	int ret;
 
 	lxc_attach_options_t attach_options = LXC_ATTACH_OPTIONS_DEFAULT;
+	attach_options.attach_flags = attach_flags;
 
 	attach_options.env_policy = LXC_ATTACH_KEEP_ENV;
 	if (clear_env) {

--- a/lxc-binding.h
+++ b/lxc-binding.h
@@ -65,7 +65,8 @@ extern int go_lxc_attach_run_wait(struct lxc_container *c,
 		char *initial_cwd,
 		char **extra_env_vars,
 		char **extra_keep_env,
-		const char * const argv[]);
+		const char * const argv[],
+		int attach_flags);
 extern int go_lxc_attach(struct lxc_container *c,
 		bool clear_env,
 		int namespaces,
@@ -74,7 +75,8 @@ extern int go_lxc_attach(struct lxc_container *c,
 		int stdinfd, int stdoutfd, int stderrfd,
 		char *initial_cwd,
 		char **extra_env_vars,
-		char **extra_keep_env);
+		char **extra_keep_env,
+		int attach_flags);
 extern int go_lxc_attach_no_wait(struct lxc_container *c,
 		bool clear_env,
 		int namespaces,
@@ -85,7 +87,8 @@ extern int go_lxc_attach_no_wait(struct lxc_container *c,
 		char **extra_env_vars,
 		char **extra_keep_env,
 		const char * const argv[],
-		pid_t *attached_pid);
+		pid_t *attached_pid,
+		int attach_flags);
 extern int go_lxc_console_getfd(struct lxc_container *c, int ttynum);
 extern int go_lxc_snapshot_list(struct lxc_container *c, struct lxc_snapshot **ret);
 extern int go_lxc_snapshot(struct lxc_container *c);

--- a/options.go
+++ b/options.go
@@ -48,22 +48,34 @@ type AttachOptions struct {
 
 	// StderrFd specifies the fd to write error output to.
 	StderrFd uintptr
+
+	// RemountSysProc remounts /sys and /proc for the executed command.
+	// This is required to reflect the container (PID) namespace context
+	// if the command does not attach to the container's mount namespace.
+	RemountSysProc bool
+
+	// ElevatedPrivileges runs the command with elevated privileges.
+	// The capabilities, cgroup and security module restrictions of the container are not applied.
+	// WARNING: This may leak privileges into the container.
+	ElevatedPrivileges bool
 }
 
 // DefaultAttachOptions is a convenient set of options to be used.
 var DefaultAttachOptions = AttachOptions{
-	Namespaces: -1,
-	Arch:       -1,
-	Cwd:        "/",
-	UID:        -1,
-	GID:        -1,
-	Groups:     nil,
-	ClearEnv:   false,
-	Env:        nil,
-	EnvToKeep:  nil,
-	StdinFd:    os.Stdin.Fd(),
-	StdoutFd:   os.Stdout.Fd(),
-	StderrFd:   os.Stderr.Fd(),
+	Namespaces:         -1,
+	Arch:               -1,
+	Cwd:                "/",
+	UID:                -1,
+	GID:                -1,
+	Groups:             nil,
+	ClearEnv:           false,
+	Env:                nil,
+	EnvToKeep:          nil,
+	StdinFd:            os.Stdin.Fd(),
+	StdoutFd:           os.Stdout.Fd(),
+	StderrFd:           os.Stderr.Fd(),
+	RemountSysProc:     false,
+	ElevatedPrivileges: false,
 }
 
 // TemplateOptions type is used for defining various template options.


### PR DESCRIPTION
Add attach option RemountSysProc to remount /sys and /proc for
the executed command (similar 'lxc-attach --remount-sys-proc').
Add attach option ElevatedPrivileges to elevate all privileges of the
executed command (similar to 'lxc-attach --elevated-privileges').

Signed-off-by: Ruben Jenster <r.jenster@drachenfels.de>