### PR TITLE
Fix compilation with lxc >= 4.0.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/lxc/go-lxc
 
 go 1.16
 
-require golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6
+require golang.org/x/sys v0.0.0-20210521203332-0cec03c779c1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6 h1:cdsMqa2nXzqlgs183pHxtvoVwU7CyzaCTAUOg94af4c=
-golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210521203332-0cec03c779c1 h1:lCnv+lfrU9FRPGf8NeRuWAAPjNnema5WtBinMgs1fD8=
+golang.org/x/sys v0.0.0-20210521203332-0cec03c779c1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/lxc-binding.c
+++ b/lxc-binding.c
@@ -314,7 +314,7 @@ int go_lxc_attach_no_wait(struct lxc_container *c,
 
 	attach_options.uid = uid;
 	attach_options.gid = gid;
-#if VERSION_AT_LEAST(4, 1, 0)
+#if VERSION_AT_LEAST(4, 0, 9)
 	if ( groups.size > 0 ) {
 		attach_options.groups = groups;
 		attach_options.attach_flags &= LXC_ATTACH_SETGROUPS;
@@ -365,7 +365,7 @@ int go_lxc_attach(struct lxc_container *c,
 
 	attach_options.uid = uid;
 	attach_options.gid = gid;
-#if VERSION_AT_LEAST(4, 1, 0)
+#if VERSION_AT_LEAST(4, 0, 9)
 	if ( groups.size > 0 ) {
 		attach_options.groups = groups;
 		attach_options.attach_flags &= LXC_ATTACH_SETGROUPS;
@@ -420,7 +420,7 @@ int go_lxc_attach_run_wait(struct lxc_container *c,
 
 	attach_options.uid = uid;
 	attach_options.gid = gid;
-#if VERSION_AT_LEAST(4, 1, 0)
+#if VERSION_AT_LEAST(4, 0, 9)
 	if ( groups.size > 0 ) {
 		attach_options.groups = groups;
 		attach_options.attach_flags &= LXC_ATTACH_SETGROUPS;

--- a/lxc-binding.h
+++ b/lxc-binding.h
@@ -49,7 +49,7 @@ extern char* go_lxc_get_running_config_item(struct lxc_container *c, const char 
 extern const char* go_lxc_get_config_path(struct lxc_container *c);
 extern const char* go_lxc_state(struct lxc_container *c);
 
-#if !VERSION_AT_LEAST(4, 1, 0) && !defined(LXC_ATTACH_SETGROUPS)
+#if !VERSION_AT_LEAST(4, 0, 9) && !defined(LXC_ATTACH_SETGROUPS)
 typedef struct lxc_groups_t {
 	size_t size;
 	gid_t *list;


### PR DESCRIPTION
Hi @stgraber

I noticed that the groups option to keep additional group ID was
merged into lxc 4.0.9 which is awesome!
This updates the version check or compilation will fail.

```
# gopkg.in/lxc/go-lxc.v2
In file included from /go/pkg/mod/gopkg.in/lxc/go-lxc.v2@v2.0.0-20210205143421-c4b883be4881/container.go:11:
./lxc-binding.h:50:16: error: redefinition of 'struct lxc_groups_t'
 typedef struct lxc_groups_t {
                ^~~~~~~~~~~~
In file included from /usr/local/include/lxc/lxccontainer.h:12,
                 from /go/pkg/mod/gopkg.in/lxc/go-lxc.v2@v2.0.0-20210205143421-c4b883be4881/container.go:9:
/usr/local/include/lxc/attach_options.h:80:16: note: originally defined here
 typedef struct lxc_groups_t {
                ^~~~~~~~~~~~
In file included from /go/pkg/mod/gopkg.in/lxc/go-lxc.v2@v2.0.0-20210205143421-c4b883be4881/container.go:11:
./lxc-binding.h:53:3: error: conflicting types for 'lxc_groups_t'
 } lxc_groups_t;
   ^~~~~~~~~~~~
In file included from /usr/local/include/lxc/lxccontainer.h:12,
                 from /go/pkg/mod/gopkg.in/lxc/go-lxc.v2@v2.0.0-20210205143421-c4b883be4881/container.go:9:
/usr/local/include/lxc/attach_options.h:83:3: note: previous declaration of 'lxc_groups_t' was here
 } lxc_groups_t;
   ^~~~~~~~~~~~
```