### PR TITLE
Update readme and Makefile to use github.com/lxc/go-lxc  import path.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ cover:
 	@`which go` tool cover -func=/tmp/unpriv.out || true
 
 doc:
-	@`which godoc` gopkg.in/lxc/go-lxc.v2 | less
+	@`which go` doc github.com/lxc/go-lxc | less
 
 vet:
 	@echo "$(OK_COLOR)==> Running go vet $(NO_COLOR)"

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This package implements [Go](https://golang.org) bindings for the [LXC](https://
 Type            | Service               | Status
 ---             | ---                   | ---
 CI (Linux)      | Github                | [![CI tests](https://github.com/lxc/go-lxc/actions/workflows/test.yml/badge.svg?branch=v2)](https://github.com/lxc/go-lxc/actions/workflows/test.yml)
-Go documentation    | Godoc                 | [![GoDoc](https://godoc.org/gopkg.in/lxc/go-lxc.v2?status.svg)](https://godoc.org/gopkg.in/lxc/go-lxc.v2)
-Static analysis     | GoReport              | [![Go Report Card](https://goreportcard.com/badge/gopkg.in/lxc/go-lxc.v2)](https://goreportcard.com/report/gopkg.in/lxc/go-lxc.v2)
+Go documentation    | Godoc                 | [![GoDoc](https://godoc.org/github.com/lxc/go-lxc?status.svg)](https://godoc.org/github.com/lxc/go-lxc)
+Static analysis     | GoReport              | [![Go Report Card](https://goreportcard.com/badge/github.com/lxc/go-lxc)](https://goreportcard.com/report/github.com/lxc/go-lxc)
 
 ## Requirements
 
@@ -31,7 +31,7 @@ sudo apt install git golang gcc make liblxc1 liblxc-dev lxc-utils pkg-config
 To install it, run:
 
 ```bash
-go get gopkg.in/lxc/go-lxc.v2
+go get github.com/lxc/go-lxc
 ```
 
 ## Trying
@@ -39,7 +39,7 @@ go get gopkg.in/lxc/go-lxc.v2
 To try examples, run:
 
 ```bash
-# cd ~/go/src/gopkg.in/lxc/go-lxc.v2/examples/
+# cd ~/go/src/github.com/lxc/go-lxc/examples/
 
 # make
 ==> Running go vet
@@ -62,16 +62,12 @@ exit
 2018/12/27 22:39:52 RunCommand
 uid=0(root) gid=0(root) groups=0(root)
 
-# stop/stop 
+# stop/stop
 2018/12/27 22:39:54 Stopping the container...
 
-# destroy/destroy 
+# destroy/destroy
 2018/12/27 22:39:57 Destroying container...
 ```
-
-## Stability
-
-The package API will remain stable as described in [gopkg.in](https://gopkg.in).
 
 ## Backwards Compatibility
 

--- a/README.md
+++ b/README.md
@@ -42,18 +42,18 @@ To try examples, run:
 # cd ~/go/src/gopkg.in/lxc/go-lxc.v2/examples/
 
 # make
-==> Running go vet 
+==> Running go vet
 ==> Building ...
 ...
 
 # create/create
 2018/12/27 22:39:27 Creating container...
 
-# start/start 
+# start/start
 2018/12/27 22:39:39 Starting the container...
 2018/12/27 22:39:39 Waiting container to startup networking...
 
-# attach/attach 
+# attach/attach
 2018/12/27 22:39:46 AttachShell
 root@rubik:/# hostname
 rubik


### PR DESCRIPTION
I've replaced all `gopkg.in/lxc/go-lxc.v2` paths in the README.md and in the `doc` target of the Makefile with the module import path `github.com/lxc/go-lxc`. The gopkg.in import path is deprecated and breaks module replacement 
for development.

Refs #155