### PR TITLE
go.mod: change module path to gopkg.in and set to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/lxc/go-lxc
+module gopkg.in/lxc/go-lxc.v2
 
 go 1.16
 


### PR DESCRIPTION
While trying to update to a newer version of go-lxc in my local LXD stable-4.0 branch, I noticed that the version of go-lxc is quite old. In fact, it predates the introduction of the go.mod file (even on lxd master branch)

Inside of the lxd codebase, go-lxc is imported through gopkg.in, and the library is already at v2. This should be reflected inside the go.mod file of go-lxc: It should contain the path that is actually used by users of the library. It should also contain the major version when >= v2.

Please be aware that I'm by no means an expert on go modules.

I'm able to use the library from my local stable-4.0 branch when adding the following change to go.mod:
```
diff --git a/go.mod b/go.mod
index 406dce5..72a8c35 100644
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.29.1
 
 replace golang.org/x/net => golang.org/x/net v0.0.0-20211020060615-d418f374d309
 
+replace gopkg.in/lxc/go-lxc.v2 => gopkg.in/eraserix/go-lxc.v2 v2.0.0-20220627150046-d6ea19e3f47e
+
 require (
        github.com/Rican7/retry v0.3.1
        github.com/armon/go-proxyproto v0.0.0-20210323213023-7e956b284f0a
```