### PR TITLE
container: add SetTimeout

### DIFF
--- a/container.go
+++ b/container.go
@@ -408,6 +408,23 @@ func (c *Container) SeccompNotifyFdActive() (*os.File, error) {
 	return os.NewFile(uintptr(notifyFd), "seccomp notify"), nil
 }
 
+// SetTimeout sets the response receive timeout for commands
+func (c *Container) SetTimeout(timeout time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.container == nil {
+		return ErrNotDefined
+	}
+
+	ret := int(C.go_lxc_set_timeout(c.container, C.int(timeout.Seconds())))
+	if ret < 0 {
+		return unix.Errno(-ret)
+	}
+
+	return nil
+}
+
 // Daemonize returns true if the container wished to be daemonized.
 func (c *Container) Daemonize() bool {
 	c.mu.RLock()

--- a/lxc-binding.c
+++ b/lxc-binding.c
@@ -75,6 +75,17 @@ int go_lxc_seccomp_notify_fd_active(struct lxc_container *c) {
 #endif
 }
 
+int go_lxc_set_timeout(struct lxc_container *c, int timeout) {
+#if VERSION_AT_LEAST(5, 0, 4)
+	if (!c->set_timeout(c, timeout))
+		return ret_errno(EINVAL);
+
+	return 0;
+#else
+	return ret_errno(ENOSYS);
+#endif
+}
+
 int go_lxc_devpts_fd(struct lxc_container *c) {
 #if VERSION_AT_LEAST(4, 0, 5)
 	return c->devpts_fd(c);

--- a/lxc-binding.h
+++ b/lxc-binding.h
@@ -97,6 +97,7 @@ extern int go_lxc_init_pidfd(struct lxc_container *c);
 extern int go_lxc_devpts_fd(struct lxc_container *c);
 extern int go_lxc_seccomp_notify_fd(struct lxc_container *c);
 extern int go_lxc_seccomp_notify_fd_active(struct lxc_container *c);
+extern int go_lxc_set_timeout(struct lxc_container *c, int timeout);
 extern bool go_lxc_checkpoint(struct lxc_container *c, char *directory, bool stop, bool verbose);
 extern bool go_lxc_restore(struct lxc_container *c, char *directory, bool verbose);
 extern bool go_lxc_config_item_is_supported(const char *key);


### PR DESCRIPTION
Extend container API with a new method SetTimeout
which allows to set SO_RCVTIMEO for LXC client socket.

Issue #4257

Signed-off-by: Alexander Mikhalitsyn <aleksandr.mikhalitsyn@canonical.com>

See https://github.com/lxc/lxc/issues/4257