### PR TITLE
container: Better handle lxc_start

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,15 @@ jobs:
       - name: Install dependencies
         run: |
           sudo add-apt-repository ppa:ubuntu-lxc/daily -y
-          sudo apt-get install -qq apparmor lxc lxc-dev pkg-config uidmap busybox libdbus-1-dev libseccomp-dev libcap-dev libselinux-dev
+          sudo apt-get install -qq apparmor lxc lxc-dev pkg-config uidmap busybox libdbus-1-dev libseccomp-dev libcap-dev libselinux-dev nftables iptables
+
+      - name: Reset all firewalling
+        run: |
+          sudo iptables -F
+          sudo iptables -P INPUT ACCEPT
+          sudo iptables -P OUTPUT ACCEPT
+          sudo iptables -P FORWARD ACCEPT
+          sudo nft flush ruleset
 
       - name: Setup test environment
         run: |

--- a/container.go
+++ b/container.go
@@ -647,9 +647,16 @@ func (c *Container) StartWithArgs(args []string) error {
 		return err
 	}
 
-	if !bool(C.go_lxc_start(c.container, 0, makeNullTerminatedArgs(args))) {
-		return ErrStartFailed
+	if args != nil {
+		if !bool(C.go_lxc_start(c.container, 0, makeNullTerminatedArgs(args))) {
+			return ErrStartFailed
+		}
+	} else {
+		if !bool(C.go_lxc_start(c.container, 0, nil)) {
+			return ErrStartFailed
+		}
 	}
+
 	return nil
 }
 
@@ -667,8 +674,14 @@ func (c *Container) StartExecute(args []string) error {
 		return err
 	}
 
-	if !bool(C.go_lxc_start(c.container, 1, makeNullTerminatedArgs(args))) {
-		return ErrStartFailed
+	if args != nil {
+		if !bool(C.go_lxc_start(c.container, 1, makeNullTerminatedArgs(args))) {
+			return ErrStartFailed
+		}
+	} else {
+		if !bool(C.go_lxc_start(c.container, 1, nil)) {
+			return ErrStartFailed
+		}
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/lxc/go-lxc
 
 go 1.20
 
-require golang.org/x/sys v0.12.0
+require golang.org/x/sys v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
-golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/lxc_test.go
+++ b/lxc_test.go
@@ -42,11 +42,6 @@ func unprivileged() bool {
 	return os.Geteuid() != 0
 }
 
-func travis() bool {
-	// https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
-	return os.Getenv("TRAVIS") == "true"
-}
-
 func supported(moduleName string) bool {
 	if _, err := os.Stat("/sys/module/" + moduleName); err != nil {
 		return false

--- a/lxc_test.go
+++ b/lxc_test.go
@@ -1412,10 +1412,6 @@ func TestIPv4Addresses(t *testing.T) {
 }
 
 func TestIPv6Addresses(t *testing.T) {
-	if !ipv6() {
-		t.Skip("skipping test since lxc bridge does not have ipv6 address")
-	}
-
 	c, err := NewContainer(ContainerName())
 	if err != nil {
 		t.Errorf(err.Error())

--- a/lxc_test.go
+++ b/lxc_test.go
@@ -1406,6 +1406,9 @@ func TestIPv4Addresses(t *testing.T) {
 	}
 	defer c.Release()
 
+	// Wait for IP configuration.
+	time.Sleep(5 * time.Second)
+
 	if _, err := c.IPv4Addresses(); err != nil {
 		t.Errorf(err.Error())
 	}
@@ -1417,6 +1420,9 @@ func TestIPv6Addresses(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 	defer c.Release()
+
+	// Wait for IP configuration.
+	time.Sleep(5 * time.Second)
 
 	if _, err := c.IPv6Addresses(); err != nil {
 		t.Errorf(err.Error())


### PR DESCRIPTION
This fixes handling for a `nil` args which can then be used to have liblxc use the default init.cmd or execute.cmd.