### PR TITLE
Fix Migrate API incorrectly calling isNotDefined

### DIFF
--- a/container.go
+++ b/container.go
@@ -2115,7 +2115,7 @@ func (c *Container) Migrate(cmd uint, opts MigrateOptions) error {
 		return ErrNotDefined
 	}
 
-	if err := c.makeSure(isNotDefined | isGreaterEqualThanLXC20); err != nil {
+	if err := c.makeSure(isGreaterEqualThanLXC20); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Not sure what the original use case was here but currently calling the Migrate API just fails instantly, can't perform checkpoint or restore. The explicit Checkpoint and Restore APIs don't have this check and work fine. Came accross this since the regular Checkpoint doesn't support predumps.